### PR TITLE
Feature to fire large number of events from opc-plc

### DIFF
--- a/src/PlcNodeManager.cs
+++ b/src/PlcNodeManager.cs
@@ -118,6 +118,46 @@ namespace OpcPlc
         }
 
 #pragma warning disable IDE0060 // Remove unused parameter
+        public void UpdateEventInstances(object state, ElapsedEventArgs elapsedEventArgs)
+#pragma warning restore IDE0060 // Remove unused parameter
+        {
+            UpdateEventInstances();
+        }
+
+#pragma warning disable IDE0060 // Remove unused parameter
+        public void UpdateVeryFastEventInstances(object state, FastTimerElapsedEventArgs elapsedEventArgs)
+#pragma warning restore IDE0060 // Remove unused parameter
+        {
+            UpdateEventInstances();
+        }
+
+        private void UpdateEventInstances()
+        {
+            uint eventInstanceCycle = _eventInstanceCycle++;
+
+            for (uint i=0; i<PlcSimulation.EventInstanceCount; i++)
+            {
+                var e = new BaseEventState(null);
+                var info = new TranslationInfo(
+                    "EventInstanceCycleEventKey",
+                    "en-us",
+                    "Event with index '{0}' and event cycle '{1}'",
+                    i, eventInstanceCycle);
+
+                e.Initialize(
+                    SystemContext,
+                    null,
+                    (EventSeverity)EventSeverity.Medium,
+                    new LocalizedText(info));
+
+                e.SetChildValue(SystemContext, Opc.Ua.BrowseNames.SourceName, "System", false);
+                e.SetChildValue(SystemContext, Opc.Ua.BrowseNames.SourceNode, Opc.Ua.ObjectIds.Server, false);
+
+                Server.ReportEvent(e);
+            };
+        }
+
+#pragma warning disable IDE0060 // Remove unused parameter
         public void UpdateBoiler1(object state, ElapsedEventArgs elapsedEventArgs)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
@@ -1059,6 +1099,7 @@ namespace OpcPlc
 
         private uint _slowBadNodesCycle = 0;
         private uint _fastBadNodesCycle = 0;
+        private uint _eventInstanceCycle = 0;
 
         private BaseDataVariableState _slowNumberOfUpdates;
         private BaseDataVariableState _fastNumberOfUpdates;

--- a/src/PlcSimulation.cs
+++ b/src/PlcSimulation.cs
@@ -42,6 +42,9 @@ namespace OpcPlc
         public static bool AddSimpleEventsSimulation { get; set; }
         public static bool AddReferenceTestSimulation { get; set; }
 
+        public static uint EventInstanceCount { get; set; } = 0;
+        public static uint EventInstanceRate { get; set; } = 1000; // ms.
+
         /// <summary>
         /// Simulation data.
         /// </summary>
@@ -106,6 +109,13 @@ namespace OpcPlc
                     _plcServer.TimeService.NewFastTimer(_plcServer.PlcNodeManager.UpdateVeryFastNodes, FastNodeRate);
             }
 
+            if (EventInstanceCount > 0)
+            {
+                _eventInstanceGenerator = EventInstanceRate >= 50 || !Stopwatch.IsHighResolution ?
+                    _plcServer.TimeService.NewTimer(_plcServer.PlcNodeManager.UpdateEventInstances, EventInstanceRate) :
+                    _plcServer.TimeService.NewFastTimer(_plcServer.PlcNodeManager.UpdateVeryFastEventInstances, EventInstanceRate);
+            }
+
             if (AddComplexTypeBoiler)
             {
                 _boiler1Generator = _plcServer.TimeService.NewTimer(_plcServer.PlcNodeManager.UpdateBoiler1, 1000);
@@ -149,6 +159,7 @@ namespace OpcPlc
 
             Disable(_slowNodeGenerator);
             Disable(_fastNodeGenerator);
+            Disable(_eventInstanceGenerator);
             Disable(_boiler1Generator);
         }
 
@@ -376,6 +387,7 @@ namespace OpcPlc
 
         private ITimer _slowNodeGenerator;
         private ITimer _fastNodeGenerator;
+        private ITimer _eventInstanceGenerator;
 
         private ITimer _boiler1Generator;
     }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -243,6 +243,10 @@
                 { "fsi|fastnodesamplinginterval=", $"rate in milliseconds to sample fast nodes\nDefault: {FastNodeSamplingInterval}", (uint i) => FastNodeSamplingInterval = i },
                 { "vfr|veryfastrate=", $"rate in milliseconds to change fast nodes\nDefault: {FastNodeRate}", (uint i) => FastNodeRate = i },
 
+                // events
+                { "ei|eventinstances=", $"number of event instances\nDefault: {EventInstanceCount}", (uint i) => EventInstanceCount = i },
+                { "er|eventrate=", $"rate in milliseconds to send events\nDefault: {EventInstanceRate}", (uint i) => EventInstanceRate = i },
+
                 // user defined nodes configuration
                 { "nf|nodesfile=", "the filename which contains the list of nodes to be created in the OPC UA address space.", (string l) => NodesFileName = l },
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Added feature to generate events similar to how we generate changes to fast nodes. Added command-line options --ei and --er to control this

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Specify how many instances of events we should fire per cycle with the --ei command-line parameter (defaults to 0, which means the feature is disabled). Specify how often these events should be fired by setting the update rate --er command-line parameter. This is set in milliseconds and the default is 1000 ms, that is once per second.

