### PR TITLE
Add OPC UA methods to stop and start updating value of fast and slow nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,17 @@ More information about this feature can be found [here](deterministic-alarms.md)
   - `0`: Slow and Fast nodes are not updated
   - `> 0`: Slow and Fast nodes are updated the given number of times, then they stop being updated (the value of the configuration node is decremented at every update).
 
+## OPC UA Methods
+
+| Name | Description | Prerequisite
+---|---|---
+ResetTrend | Reset the trend values to their baseline value | Generate positive or negative trends activated
+ResetStepUp | Resets the StepUp counter to 0 | Generate data activated
+StartStepUp | Starts the StepUp counter | Generate data activated
+StopStepUp | Stops the StepUp counter | Generate data activated
+StopUpdateFastAndSlowNodes | Stops the increase of value of fast and slow nodes | slow nodes or fast nodes activated
+StartUpdateFastAndSlowNodes | Start the increase of value of fast and slow nodes | slow nodes or fast nodes activated
+
 ## Build
 
 The build scripts are for Azure DevOps and the container build is done in ACR. To use your own ACR you need to:

--- a/src/PlcNodeManager.cs
+++ b/src/PlcNodeManager.cs
@@ -67,7 +67,7 @@ namespace OpcPlc
         public void UpdateSlowNodes(object state, ElapsedEventArgs elapsedEventArgs)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            if (!ShouldUpdateNodes(_slowNumberOfUpdates))
+            if (!ShouldUpdateNodes(_slowNumberOfUpdates) || !_updateFastAndSlowNodes)
             {
                 return;
             }
@@ -100,7 +100,7 @@ namespace OpcPlc
 
         private void UpdateNodes()
         {
-            if (!ShouldUpdateNodes(_fastNumberOfUpdates))
+            if (!ShouldUpdateNodes(_fastNumberOfUpdates) || !_updateFastAndSlowNodes)
             {
                 return;
             }
@@ -442,6 +442,14 @@ namespace OpcPlc
                 SetStopStepUpMethodProperties(ref stopStepUpMethod);
             }
 
+            if (PlcSimulation.SlowNodeType > 0 || PlcSimulation.FastNodeCount > 0)
+            {
+                MethodState stopUpdateFastAndSlowNodesMethod = CreateMethod(methodsFolder, "StopUpdateFastAndSlowNodes", "StopUpdateFastAndSlowNodes", "Stops the increase of value of fast and slow nodes", NamespaceType.OpcPlcApplications);
+                SetStopUpdateFastAndSlowNodesProperties(ref stopUpdateFastAndSlowNodesMethod);
+                MethodState startUpdateFastAndSlowNodesMethod = CreateMethod(methodsFolder, "StartUpdateFastAndSlowNodes", "StartUpdateFastAndSlowNodes", "Start the increase of value of fast and slow nodes", NamespaceType.OpcPlcApplications);
+                SetStartUpdateFastAndSlowNodesProperties(ref startUpdateFastAndSlowNodesMethod);
+            }
+
             return methodsFolder;
         }
 
@@ -697,6 +705,22 @@ namespace OpcPlc
         private void SetStopStepUpMethodProperties(ref MethodState method)
         {
             method.OnCallMethod = new GenericMethodCalledEventHandler(OnStopStepUpCall);
+        }
+
+        /// <summary>
+        /// Sets properties of the StopUpdateFastAndSlowNodes method.
+        /// </summary>
+        private void SetStopUpdateFastAndSlowNodesProperties(ref MethodState method)
+        {
+            method.OnCallMethod = new GenericMethodCalledEventHandler(OnStopUpdateFastAndSlowNodes);
+        }
+
+        /// <summary>
+        /// Sets properties of the StartUpdateFastAndSlowNodes method.
+        /// </summary>
+        private void SetStartUpdateFastAndSlowNodesProperties(ref MethodState method)
+        {
+            method.OnCallMethod = new GenericMethodCalledEventHandler(OnStartUpdateFastAndSlowNodes);
         }
 
         /// <summary>
@@ -1048,6 +1072,26 @@ namespace OpcPlc
         }
 
         /// <summary>
+        /// Method to stop updating the fast and slow nodes
+        /// </summary>
+        private ServiceResult OnStopUpdateFastAndSlowNodes(ISystemContext context, MethodState method, IList<object> inputArguments, IList<object> outputArguments)
+        {
+            _updateFastAndSlowNodes = false;
+            Logger.Debug("StopUpdateFastAndSlowNodes method called");
+            return ServiceResult.Good;
+        }
+
+        /// <summary>
+        /// Method to stop updating the fast and slow nodes
+        /// </summary>
+        private ServiceResult OnStartUpdateFastAndSlowNodes(ISystemContext context, MethodState method, IList<object> inputArguments, IList<object> outputArguments)
+        {
+            _updateFastAndSlowNodes = true;
+            Logger.Debug("StartUpdateFastAndSlowNodes method called");
+            return ServiceResult.Good;
+        }
+
+        /// <summary>
         /// Method to turn the heater on. Executes synchronously.
         /// </summary>
         private ServiceResult OnHeaterOnCall(ISystemContext context, MethodState method, IList<object> inputArguments, IList<object> outputArguments)
@@ -1121,6 +1165,7 @@ namespace OpcPlc
         private readonly string _fastNodeMinValue;
         private readonly string _fastNodeMaxValue;
         private readonly Random _random;
+        private bool _updateFastAndSlowNodes = true;
 
         /// <summary>
         /// File name for user configurable nodes.

--- a/src/PlcNodeManager.cs
+++ b/src/PlcNodeManager.cs
@@ -442,7 +442,7 @@ namespace OpcPlc
                 SetStopStepUpMethodProperties(ref stopStepUpMethod);
             }
 
-            if (PlcSimulation.SlowNodeType > 0 || PlcSimulation.FastNodeCount > 0)
+            if (PlcSimulation.SlowNodeCount > 0 || PlcSimulation.FastNodeCount > 0)
             {
                 MethodState stopUpdateFastAndSlowNodesMethod = CreateMethod(methodsFolder, "StopUpdateFastAndSlowNodes", "StopUpdateFastAndSlowNodes", "Stops the increase of value of fast and slow nodes", NamespaceType.OpcPlcApplications);
                 SetStopUpdateFastAndSlowNodesProperties(ref stopUpdateFastAndSlowNodesMethod);

--- a/tests/PlcSimulatorFixture.cs
+++ b/tests/PlcSimulatorFixture.cs
@@ -117,13 +117,16 @@ namespace OpcPlc.Tests
             mock.Setup(f => f.UtcNow())
                 .Returns(() => _now);
 
-            // The simulator program command line.            
+            // The simulator program command line.
             _serverTask = Task.Run(() => Program.MainAsync(
                     _args.Concat(
                             new[]
                             {
                                 "--autoaccept",
                                 $"--portnum={Port}",
+                                "--fn=25",
+                                "--fr=1",
+                                "--ft=uint"
                             })
                         .ToArray(),
                     _serverCancellationTokenSource.Token)

--- a/tests/SimulatorTestsBase.cs
+++ b/tests/SimulatorTestsBase.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace OpcPlc.Tests
 {
@@ -147,6 +149,14 @@ namespace OpcPlc.Tests
                 out _);
 
             return results;
+        }
+
+        /// <summary>
+        /// Calls OPC UA method over active session
+        /// </summary>
+        protected IList<object> CallMethod(string methodName, string objectName = "Methods", params object[] args)
+        {
+            return Session.Call(GetOpcPlcNodeId(objectName), GetOpcPlcNodeId(methodName), args);
         }
     }
 }


### PR DESCRIPTION
## Purpose
* Added methods to control the Fast and Slow nodes to allow control in test environment

## Does this introduce a breaking change?
```
[ ] Yes
[X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[ X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  execute test SimulatorNodesTests.Telemetry_FastNode() in visual studio test runner

## What to Check
Verify that the following are valid
* n/a

## Other Information
* n/a