### PR TITLE
Set MaxPublishingRequestCount to same MaxSubscriptionCount

### DIFF
--- a/src/OpcApplicationConfiguration.cs
+++ b/src/OpcApplicationConfiguration.cs
@@ -171,6 +171,7 @@
             ApplicationConfiguration.ServerConfiguration.MaxMessageQueueSize = MAX_MESSAGE_QUEUE_SIZE;
             ApplicationConfiguration.ServerConfiguration.MaxNotificationsPerPublish = MAX_NOTIFICATIONS_PER_PUBLISH;
             ApplicationConfiguration.ServerConfiguration.MaxSubscriptionCount = MAX_SUBSCRIPTION_COUNT;
+            ApplicationConfiguration.ServerConfiguration.MaxPublishRequestCount = MAX_PUBLISH_REQUEST_COUNT;
 
             return ApplicationConfiguration;
         }
@@ -228,6 +229,7 @@
         private const int MAX_MESSAGE_QUEUE_SIZE = 200000;
         private const int MAX_NOTIFICATIONS_PER_PUBLISH = 200000;
         private const int MAX_SUBSCRIPTION_COUNT = 200;
+        private const int MAX_PUBLISH_REQUEST_COUNT = 200;
 
         private static string _hostname = $"{Utils.GetHostName().ToLowerInvariant()}";
     }

--- a/src/OpcApplicationConfiguration.cs
+++ b/src/OpcApplicationConfiguration.cs
@@ -172,6 +172,7 @@
             ApplicationConfiguration.ServerConfiguration.MaxNotificationsPerPublish = MAX_NOTIFICATIONS_PER_PUBLISH;
             ApplicationConfiguration.ServerConfiguration.MaxSubscriptionCount = MAX_SUBSCRIPTION_COUNT;
             ApplicationConfiguration.ServerConfiguration.MaxPublishRequestCount = MAX_PUBLISH_REQUEST_COUNT;
+            ApplicationConfiguration.ServerConfiguration.MaxRequestThreadCount = MAX_REQUEST_THREAD_COUNT;
 
             return ApplicationConfiguration;
         }
@@ -229,7 +230,8 @@
         private const int MAX_MESSAGE_QUEUE_SIZE = 200000;
         private const int MAX_NOTIFICATIONS_PER_PUBLISH = 200000;
         private const int MAX_SUBSCRIPTION_COUNT = 200;
-        private const int MAX_PUBLISH_REQUEST_COUNT = 200;
+        private const int MAX_PUBLISH_REQUEST_COUNT = MAX_SUBSCRIPTION_COUNT;
+        private const int MAX_REQUEST_THREAD_COUNT = MAX_PUBLISH_REQUEST_COUNT;
 
         private static string _hostname = $"{Utils.GetHostName().ToLowerInvariant()}";
     }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.2.6-beta1",
+  "version": "2.0.0",
   "versionHeightOffset": -1,
   "publicReleaseRefSpec": [
     "^refs/heads/master$",


### PR DESCRIPTION
## Purpose

* The UA-.NET standard client creates at least on publishing request per subscription created. The OPC PLC set max subscription to 200 but the max publishing request is using the stack default of 20.

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Build OPC PLC from source
* Start OPC PLC 
* Connect UA-.NET OPC UA Client and create more than 20 Subscriptions
* Observe that no exception of type `BadTooManyPublishingRequests` is thrown

## What to Check
Verify that the following are valid
* More then subscription could be created

## Other Information
