### PR TITLE
Add alternate base address

### DIFF
--- a/src/CliOptions.cs
+++ b/src/CliOptions.cs
@@ -114,9 +114,9 @@ public class CliOptions
                 { "csr", $"show data to create a certificate signing request\nDefault '{ShowCreateSigningRequestInfo}'", (string s) => ShowCreateSigningRequestInfo = s != null
                 },
 
-                { "ab|applicationcertbase64=", "update/set this applications certificate with the certificate passed in as bas64 string", (string s) => NewCertificateBase64String = s
+                { "ab|applicationcertbase64=", "update/set this application's certificate with the certificate passed in as bas64 string", (string s) => NewCertificateBase64String = s
                 },
-                { "af|applicationcertfile=", "update/set this applications certificate with the certificate file specified", (string s) =>
+                { "af|applicationcertfile=", "update/set this application's certificate with the certificate file specified", (string s) =>
                     {
                         if (File.Exists(s))
                         {
@@ -147,14 +147,14 @@ public class CliOptions
                 { "cp|certpassword=", "the optional password for the PEM or PFX or the installed application certificate", (string s) => CertificatePassword = s
                 },
 
-                { "tb|addtrustedcertbase64=", "adds the certificate to the applications trusted cert store passed in as base64 string (multiple strings supported)", (string s) => TrustedCertificateBase64Strings = ParseListOfStrings(s)
+                { "tb|addtrustedcertbase64=", "adds the certificate to the application's trusted cert store passed in as base64 string (multiple strings supported)", (string s) => TrustedCertificateBase64Strings = ParseListOfStrings(s)
                 },
-                { "tf|addtrustedcertfile=", "adds the certificate file(s) to the applications trusted cert store passed in as base64 string (multiple filenames supported)", (string s) => TrustedCertificateFileNames = ParseListOfFileNames(s, "addtrustedcertfile")
+                { "tf|addtrustedcertfile=", "adds the certificate file(s) to the application's trusted cert store passed in as base64 string (multiple filenames supported)", (string s) => TrustedCertificateFileNames = ParseListOfFileNames(s, "addtrustedcertfile")
                 },
 
-                { "ib|addissuercertbase64=", "adds the specified issuer certificate to the applications trusted issuer cert store passed in as base64 string (multiple strings supported)", (string s) => IssuerCertificateBase64Strings = ParseListOfStrings(s)
+                { "ib|addissuercertbase64=", "adds the specified issuer certificate to the application's trusted issuer cert store passed in as base64 string (multiple strings supported)", (string s) => IssuerCertificateBase64Strings = ParseListOfStrings(s)
                 },
-                { "if|addissuercertfile=", "adds the specified issuer certificate file(s) to the applications trusted issuer cert store (multiple filenames supported)", (string s) => IssuerCertificateFileNames = ParseListOfFileNames(s, "addissuercertfile")
+                { "if|addissuercertfile=", "adds the specified issuer certificate file(s) to the application's trusted issuer cert store (multiple filenames supported)", (string s) => IssuerCertificateFileNames = ParseListOfFileNames(s, "addissuercertfile")
                 },
 
                 { "rb|updatecrlbase64=", "update the CRL passed in as base64 string to the corresponding cert store (trusted or trusted issuer)", (string s) => CrlBase64String = s

--- a/src/CliOptions.cs
+++ b/src/CliOptions.cs
@@ -51,18 +51,18 @@ public class CliOptions
                 { "ei|eventinstances=", $"number of event instances\nDefault: {EventInstanceCount}", (uint i) => EventInstanceCount = i },
                 { "er|eventrate=", $"rate in milliseconds to send events\nDefault: {EventInstanceRate}", (uint i) => EventInstanceRate = i },
 
-                // opc configuration
+                // OPC configuration
                 { "pn|portnum=", $"the server port of the OPC server endpoint.\nDefault: {ServerPort}", (ushort i) => ServerPort = i },
                 { "op|path=", $"the enpoint URL path part of the OPC server endpoint.\nDefault: '{ServerPath}'", (string s) => ServerPath = s },
-                { "ph|plchostname=", $"the fullqualified hostname of the plc.\nDefault: {Hostname}", (string s) => Hostname = s },
-                { "ol|opcmaxstringlen=", $"the max length of a string opc can transmit/receive.\nDefault: {OpcMaxStringLength}", (int i) => {
+                { "ph|plchostname=", $"the fully-qualified hostname of the PLC.\nDefault: {Hostname}", (string s) => Hostname = s },
+                { "ol|opcmaxstringlen=", $"the max length of a string OPC can transmit/receive.\nDefault: {OpcMaxStringLength}", (int i) => {
                         if (i > 0)
                         {
                             OpcMaxStringLength = i;
                         }
                         else
                         {
-                            throw new OptionException("The max opc string length must be larger than 0.", "opcmaxstringlen");
+                            throw new OptionException("The max OPC string length must be larger than 0.", "opcmaxstringlen");
                         }
                     }
                 },

--- a/src/OpcApplicationConfiguration.cs
+++ b/src/OpcApplicationConfiguration.cs
@@ -88,7 +88,12 @@ public partial class OpcApplicationConfiguration
         // configure OPC UA server
         var serverBuilder = application.Build(ApplicationUri, ProductUri)
             .SetTransportQuotas(transportQuotas)
-            .AsServer(new string[] { $"opc.tcp://{Hostname}:{ServerPort}{ServerPath}" })
+            .AsServer(baseAddresses: new string[] {
+                $"opc.tcp://{Hostname}:{ServerPort}{ServerPath}",
+            },
+            alternateBaseAddresses: new string[] {
+                $"opc.tcp://{Utils.GetHostName().ToLowerInvariant()}:{ServerPort}{ServerPath}",
+            })
             .AddSignAndEncryptPolicies()
             .AddSignPolicies();
 
@@ -250,5 +255,5 @@ public partial class OpcApplicationConfiguration
     private const int MAX_PUBLISH_REQUEST_COUNT = MAX_SUBSCRIPTION_COUNT;
     private const int MAX_REQUEST_THREAD_COUNT = MAX_PUBLISH_REQUEST_COUNT;
 
-    private static string _hostname = $"{Utils.GetHostName().ToLowerInvariant()}";
+    private static string _hostname = Utils.GetHostName().ToLowerInvariant();
 }

--- a/src/OpcApplicationConfiguration.cs
+++ b/src/OpcApplicationConfiguration.cs
@@ -22,7 +22,9 @@ public partial class OpcApplicationConfiguration
         set => _hostname = value.ToLowerInvariant();
     }
 
-    public static string HostnameLabel => (_hostname.Contains(".") ? _hostname.Substring(0, _hostname.IndexOf('.')) : _hostname);
+    public static string HostnameLabel => _hostname.Contains('.')
+                                            ? _hostname[.._hostname.IndexOf('.')]
+                                            : _hostname;
     public static string ApplicationName => ProgramName;
     public static string ApplicationUri => $"urn:{ProgramName}:{HostnameLabel}{(string.IsNullOrEmpty(ServerPath) ? string.Empty : (ServerPath.StartsWith("/") ? string.Empty : ":"))}{ServerPath.Replace("/", ":")}";
     public static string ProductUri => "https://github.com/azure-samples/iot-edge-opc-plc";
@@ -63,13 +65,6 @@ public partial class OpcApplicationConfiguration
     /// Set the OPC stack log level.
     /// </summary>
     public static int OpcStackTraceMask { get; set; } = 0;
-
-    /// <summary>
-    /// Ctor of the OPC application configuration.
-    /// </summary>
-    public OpcApplicationConfiguration()
-    {
-    }
 
     /// <summary>
     /// Configures all OPC stack settings.

--- a/src/OpcApplicationConfiguration.cs
+++ b/src/OpcApplicationConfiguration.cs
@@ -127,7 +127,7 @@ public partial class OpcApplicationConfiguration
 
             if (policy.SecurityMode == MessageSecurityMode.None)
             {
-                Logger.Warning("Note: Security policy 'None' is a security risk and needs to be disabled for production use");
+                Logger.Warning("Security policy {none} is a security risk and needs to be disabled for production use", "None");
             }
         }
 

--- a/src/OpcApplicationConfiguration.cs
+++ b/src/OpcApplicationConfiguration.cs
@@ -121,30 +121,39 @@ public partial class OpcApplicationConfiguration
 
         foreach (var policy in ApplicationConfiguration.ServerConfiguration.SecurityPolicies)
         {
-            Logger.Information($"Added security policy {policy.SecurityPolicyUri} with mode {policy.SecurityMode}.");
+            Logger.Information("Added security policy {securityPolicyUri} with mode {securityMode}",
+                policy.SecurityPolicyUri,
+                policy.SecurityMode);
+
             if (policy.SecurityMode == MessageSecurityMode.None)
             {
-                Logger.Warning("Note: security policy 'None' is a security risk and needs to be disabled for production use");
+                Logger.Warning("Note: Security policy 'None' is a security risk and needs to be disabled for production use");
             }
         }
 
-        Logger.Information($"LDS(-ME) registration interval set to {LdsRegistrationInterval} ms (0 means no registration)");
+        Logger.Information("LDS(-ME) registration interval set to {ldsRegistrationInterval} ms (0 means no registration)",
+            LdsRegistrationInterval);
 
         // configure OPC stack tracing
         Utils.SetTraceMask(OpcStackTraceMask);
         Utils.Tracing.TraceEventHandler += LoggerOpcUaTraceHandler;
-        Logger.Information($"The OPC UA trace mask is set to: 0x{OpcStackTraceMask:X}");
+        Logger.Information("The OPC UA trace mask is set to: {opcStackTraceMask}",
+            $"0x{OpcStackTraceMask:X}");
 
         // log certificate status
         var certificate = ApplicationConfiguration.SecurityConfiguration.ApplicationCertificate.Certificate;
         if (certificate == null)
         {
-            Logger.Information($"No existing application certificate found. Creating a self-signed application certificate valid since yesterday for {CertificateFactory.DefaultLifeTime} months," +
-                $"with a {CertificateFactory.DefaultKeySize} bit key and {CertificateFactory.DefaultHashSize} bit hash.");
+            Logger.Information("No existing application certificate found. Creating a self-signed application certificate valid since yesterday for {defaultLifeTime} months, " +
+                "with a {defaultKeySize} bit key and {defaultHashSize} bit hash",
+                CertificateFactory.DefaultLifeTime,
+                CertificateFactory.DefaultKeySize,
+                CertificateFactory.DefaultHashSize);
         }
         else
         {
-            Logger.Information($"Application certificate with thumbprint '{certificate.Thumbprint}' found in the application certificate store.");
+            Logger.Information("Application certificate with thumbprint {thumbprint} found in the application certificate store",
+                certificate.Thumbprint);
         }
 
         // check the certificate, creates new self signed certificate if required
@@ -157,10 +166,14 @@ public partial class OpcApplicationConfiguration
         if (certificate == null)
         {
             certificate = ApplicationConfiguration.SecurityConfiguration.ApplicationCertificate.Certificate;
-            Logger.Information($"Application certificate with thumbprint '{certificate.Thumbprint}' created.");
+            Logger.Information("Application certificate with thumbprint {thumbprint} created",
+                certificate.Thumbprint);
         }
 
-        Logger.Information($"Application certificate is for ApplicationUri '{ApplicationConfiguration.ApplicationUri}', ApplicationName '{ApplicationConfiguration.ApplicationName}' and Subject is '{ApplicationConfiguration.SecurityConfiguration.ApplicationCertificate.Certificate.Subject}'");
+        Logger.Information("Application certificate is for ApplicationUri {applicationUri}, ApplicationName {applicationName} and Subject is {subject}",
+            ApplicationConfiguration.ApplicationUri,
+            ApplicationConfiguration.ApplicationName,
+            ApplicationConfiguration.SecurityConfiguration.ApplicationCertificate.Certificate.Subject);
 
         // show CreateSigningRequest data
         if (ShowCreateSigningRequestInfo)

--- a/src/OpcApplicationConfigurationSecurity.cs
+++ b/src/OpcApplicationConfigurationSecurity.cs
@@ -127,26 +127,28 @@ public partial class OpcApplicationConfiguration
         }
         ApplicationConfiguration = await options.Create().ConfigureAwait(false);
 
-        Logger.Information($"Application Certificate store type is: {id.StoreType}");
-        Logger.Information($"Application Certificate store path is: {id.StorePath}");
-        Logger.Information($"Application Certificate subject name is: {id.SubjectName}");
+        Logger.Information("Application Certificate store type is: {storeType}", id.StoreType);
+        Logger.Information("Application Certificate store path is: {storePath}", id.StorePath);
 
-        Logger.Information($"Rejection of SHA1 signed certificates is {(securityConfiguration.RejectSHA1SignedCertificates ? "enabled" : "disabled")}");
-        Logger.Information($"Minimum certificate key size set to {securityConfiguration.MinimumCertificateKeySize}");
+        Logger.Information("Rejection of SHA1 signed certificates is {status}",
+            securityConfiguration.RejectSHA1SignedCertificates ? "enabled" : "disabled");
 
-        Logger.Information($"Trusted Issuer store type is: {issuerList.StoreType}");
-        Logger.Information($"Trusted Issuer Certificate store path is: {issuerList.StorePath}");
+        Logger.Information("Minimum certificate key size set to {minimumCertificateKeySize}",
+            securityConfiguration.MinimumCertificateKeySize);
 
-        Logger.Information($"Trusted Peer Certificate store type is: {trustList.StoreType}");
-        Logger.Information($"Trusted Peer Certificate store path is: {trustList.StorePath}");
+        Logger.Information("Trusted Issuer store type is: {storeType}", issuerList.StoreType);
+        Logger.Information("Trusted Issuer Certificate store path is: {storePath}", issuerList.StorePath);
 
-        Logger.Information($"Rejected certificate store type is: {rejectedStore.StoreType}");
-        Logger.Information($"Rejected Certificate store path is: {rejectedStore.StorePath}");
+        Logger.Information("Trusted Peer Certificate store type is: {storeType}", trustList.StoreType);
+        Logger.Information("Trusted Peer Certificate store path is: {storePath}", trustList.StorePath);
+
+        Logger.Information("Rejected certificate store type is: {storeType}", rejectedStore.StoreType);
+        Logger.Information("Rejected Certificate store path is: {storePath}", rejectedStore.StorePath);
 
         // handle cert validation
         if (AutoAcceptCerts)
         {
-            Logger.Warning("WARNING: Automatically accepting certificates. This is a security risk.");
+            Logger.Warning("Automatically accepting all client certificates, this is a security risk!");
         }
         ApplicationConfiguration.CertificateValidator.CertificateValidation += new CertificateValidationEventHandler(CertificateValidator_CertificateValidation);
 
@@ -279,15 +281,18 @@ public partial class OpcApplicationConfiguration
             using ICertificateStore certStore = ApplicationConfiguration.SecurityConfiguration.ApplicationCertificate.OpenStore();
             var certs = await certStore.Enumerate().ConfigureAwait(false);
             int certNum = 1;
-            Logger.Information($"Application store contains {certs.Count} certs");
+            Logger.Information("Application store contains {count} certs", certs.Count);
             foreach (var cert in certs)
             {
-                Logger.Information($"{certNum++:D2}: Subject '{cert.Subject}' (thumbprint: {cert.GetCertHashString()})");
+                Logger.Information("{index}: Subject {subject} (thumbprint: {thumbprint})",
+                    $"{certNum++:D2}",
+                    cert.Subject,
+                    cert.GetCertHashString());
             }
         }
         catch (Exception e)
         {
-            Logger.Error(e, "Error while trying to read information from application store.");
+            Logger.Error(e, "Error while trying to read information from application store");
         }
 
         // show trusted issuer certs
@@ -296,19 +301,26 @@ public partial class OpcApplicationConfiguration
             using ICertificateStore certStore = ApplicationConfiguration.SecurityConfiguration.TrustedIssuerCertificates.OpenStore();
             var certs = await certStore.Enumerate().ConfigureAwait(false);
             int certNum = 1;
-            Logger.Information($"Trusted issuer store contains {certs.Count} certs");
+            Logger.Information("Trusted issuer store contains {count} certs", certs.Count);
             foreach (var cert in certs)
             {
-                Logger.Information($"{certNum++:D2}: Subject '{cert.Subject}' (thumbprint: {cert.GetCertHashString()})");
+                Logger.Information("{index}: Subject {subject} (thumbprint: {thumbprint})",
+                    $"{certNum++:D2}",
+                    cert.Subject,
+                    cert.GetCertHashString());
             }
+
             if (certStore.SupportsCRLs)
             {
                 var crls = await certStore.EnumerateCRLs().ConfigureAwait(false);
                 int crlNum = 1;
-                Logger.Information($"Trusted issuer store has {crls.Count} CRLs.");
+                Logger.Information("Trusted issuer store has {count} CRLs", crls.Count);
                 foreach (var crl in crls)
                 {
-                    Logger.Information($"{crlNum++:D2}: Issuer '{crl.Issuer}', Next update time '{crl.NextUpdate}'");
+                    Logger.Information("{index}: Issuer {issuer}, Next update time {nextUpdate}",
+                        $"{crlNum++:D2}",
+                        crl.Issuer,
+                        crl.NextUpdate);
                 }
             }
         }
@@ -323,25 +335,32 @@ public partial class OpcApplicationConfiguration
             using ICertificateStore certStore = ApplicationConfiguration.SecurityConfiguration.TrustedPeerCertificates.OpenStore();
             var certs = await certStore.Enumerate().ConfigureAwait(false);
             int certNum = 1;
-            Logger.Information($"Trusted peer store contains {certs.Count} certs");
+            Logger.Information("Trusted peer store contains {count} certs", certs.Count);
             foreach (var cert in certs)
             {
-                Logger.Information($"{certNum++:D2}: Subject '{cert.Subject}' (thumbprint: {cert.GetCertHashString()})");
+                Logger.Information("{index}: Subject {subject} (thumbprint: {thumbprint})",
+                    $"{certNum++:D2}",
+                    cert.Subject,
+                    cert.GetCertHashString());
             }
+
             if (certStore.SupportsCRLs)
             {
                 var crls = await certStore.EnumerateCRLs().ConfigureAwait(false);
                 int crlNum = 1;
-                Logger.Information($"Trusted peer store has {crls.Count} CRLs.");
+                Logger.Information("Trusted peer store has {count} CRLs", crls.Count);
                 foreach (var crl in crls)
                 {
-                    Logger.Information($"{crlNum++:D2}: Issuer '{crl.Issuer}', Next update time '{crl.NextUpdate}'");
+                    Logger.Information("{index}: Issuer {issuer}, Next update time {nextUpdate}",
+                        $"{crlNum++:D2}",
+                        crl.Issuer,
+                        crl.NextUpdate);
                 }
             }
         }
         catch (Exception e)
         {
-            Logger.Error(e, "Error while trying to read information from trusted peer store.");
+            Logger.Error(e, "Error while trying to read information from trusted peer store");
         }
 
         // show rejected peer certs
@@ -350,15 +369,18 @@ public partial class OpcApplicationConfiguration
             using ICertificateStore certStore = ApplicationConfiguration.SecurityConfiguration.RejectedCertificateStore.OpenStore();
             var certs = await certStore.Enumerate().ConfigureAwait(false);
             int certNum = 1;
-            Logger.Information($"Rejected certificate store contains {certs.Count} certs");
+            Logger.Information("Rejected certificate store contains {count} certs", certs.Count);
             foreach (var cert in certs)
             {
-                Logger.Information($"{certNum++:D2}: Subject '{cert.Subject}' (thumbprint: {cert.GetCertHashString()})");
+                Logger.Information("{index}: Subject {subject} (thumbprint: {thumbprint})",
+                    $"{certNum++:D2}",
+                    cert.Subject,
+                    cert.GetCertHashString());
             }
         }
         catch (Exception e)
         {
-            Logger.Error(e, "Error while trying to read information from rejected certificate store.");
+            Logger.Error(e, "Error while trying to read information from rejected certificate store");
         }
     }
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -159,14 +159,17 @@ public static class Program
 
         LogLogo();
 
-        Logger.Information($"Current directory: {Directory.GetCurrentDirectory()}");
-        Logger.Information($"Log file: {Path.GetFullPath(LogFileName)}");
-        Logger.Information($"Log level: {LogLevel}");
+        Logger.Information("Current directory: {currentDirectory}", Directory.GetCurrentDirectory());
+        Logger.Information("Log file: {logFileName}", Path.GetFullPath(LogFileName));
+        Logger.Information("Log level: {logLevel}", LogLevel);
 
         //show version
         var fileVersion = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location);
-        Logger.Information($"{ProgramName} V{fileVersion.ProductMajorPart}.{fileVersion.ProductMinorPart}.{fileVersion.ProductBuildPart} starting up ...");
-        Logger.Debug($"Informational version: V{(Attribute.GetCustomAttribute(Assembly.GetEntryAssembly(), typeof(AssemblyInformationalVersionAttribute)) as AssemblyInformationalVersionAttribute)?.InformationalVersion}");
+        Logger.Information("{ProgramName} {version} starting up ...",
+            ProgramName,
+            $"v{fileVersion.ProductMajorPart}.{fileVersion.ProductMinorPart}.{fileVersion.ProductBuildPart}");
+        Logger.Debug("Informational version: {version}",
+            $"v{(Attribute.GetCustomAttribute(Assembly.GetEntryAssembly(), typeof(AssemblyInformationalVersionAttribute)) as AssemblyInformationalVersionAttribute)?.InformationalVersion}");
 
         using var host = CreateHostBuilder(args);
         if (ShowPublisherConfigJsonIp || ShowPublisherConfigJsonPh)
@@ -210,11 +213,13 @@ public static class Program
         try
         {
             host.Start();
-            Logger.Information($"Web server started on port {WebServerPort}");
+            Logger.Information("Web server started on port {webServerPort}", WebServerPort);
         }
         catch (Exception e)
         {
-            Logger.Error($"Could not start web server on port {WebServerPort}: {e.Message}");
+            Logger.Error("Could not start web server on port {webServerPort}: {message}",
+                WebServerPort,
+                e.Message);
         }
     }
 
@@ -249,7 +254,7 @@ public static class Program
         ApplicationConfiguration plcApplicationConfiguration = await plcOpcApplicationConfiguration.ConfigureAsync().ConfigureAwait(false);
 
         // start the server.
-        Logger.Information($"Starting server on endpoint {plcApplicationConfiguration.ServerConfiguration.BaseAddresses[0]} ...");
+        Logger.Information("Starting server on endpoint {endpoint} (alternate: {alternate}) ...", plcApplicationConfiguration.ServerConfiguration.BaseAddresses[0], plcApplicationConfiguration.ServerConfiguration.AlternateBaseAddresses[0]);
         Logger.Information("Simulation settings are:");
         Logger.Information($"One simulation phase consists of {SimulationCycleCount} cycles");
         Logger.Information($"One cycle takes {SimulationCycleLength} ms");

--- a/src/opc-plc.csproj
+++ b/src/opc-plc.csproj
@@ -25,6 +25,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Bindings.Https.Debug" Version="1.4.370.12" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/src/opc-plc.csproj
+++ b/src/opc-plc.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
 

--- a/tests/opc-plc-tests.csproj
+++ b/tests/opc-plc-tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Serilog.Sinks.NUnit" Version="1.0.3" />
   </ItemGroup>
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "versionHeightOffset": -1,
   "publicReleaseRefSpec": [
     "^refs/heads/main$",


### PR DESCRIPTION
* Add alternate base address set to the internal DNS names. This should fix the connection issue when the internal container name doesn't match the external name used in the certificate (e.g. option `--ph`).
* Update some nuget packages
* Use semantic logging for many logs