### PR TITLE
Fix pn.json generation

### DIFF
--- a/src/Helpers/PluginNodesHelpers.cs
+++ b/src/Helpers/PluginNodesHelpers.cs
@@ -1,0 +1,45 @@
+﻿
+namespace OpcPlc.Helpers;
+
+using Opc.Ua;
+using OpcPlc.PluginNodes.Models;
+using System;
+
+/// <summary>
+/// Helper class for plugin nodes.
+/// </summary>
+public class PluginNodesHelpers
+{
+    /// <summary>
+    /// Get node with correct type prefix, id, namespace, and intervals.
+    /// </summary>
+    public static NodeWithIntervals GetNodeWithIntervals(NodeId nodeId, PlcNodeManager plcNodeManager)
+    {
+        ExpandedNodeId expandedNodeId = NodeId.ToExpandedNodeId(nodeId, plcNodeManager.Server.NamespaceUris);
+
+        return new NodeWithIntervals
+        {
+            NodeId = expandedNodeId.IdType == IdType.Opaque
+                ? Convert.ToBase64String((byte[])expandedNodeId.Identifier)
+                : expandedNodeId.Identifier.ToString(),
+            NodeIdTypePrefix = GetTypePrefix(expandedNodeId.IdType),
+            Namespace = expandedNodeId.NamespaceUri,
+        };
+    }
+
+    /// <summary>
+    /// Get a single lowercase character that represents the type of the node.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    private static string GetTypePrefix(IdType idType)
+    {
+        return idType switch
+        {
+            IdType.Numeric => "i",
+            IdType.String => "s",
+            IdType.Guid => "g",
+            IdType.Opaque => "b",
+            _ => throw new ArgumentOutOfRangeException(nameof(idType), idType.ToString(), message: null),
+        };
+    }
+}

--- a/src/Helpers/PnJsonHelper.cs
+++ b/src/Helpers/PnJsonHelper.cs
@@ -41,7 +41,7 @@ public class PnJsonHelper
                     : string.Empty;
 
                 string nodeId = JsonEncodedText.Encode(node.NodeId, JavaScriptEncoder.Default).ToString();
-                sb.AppendLine($"      {{ \"Id\": \"nsu={node.Namespace};s={nodeId}\"{publishingInterval}{samplingInterval} }},");
+                sb.AppendLine($"      {{ \"Id\": \"nsu={node.Namespace};{node.NodeIdTypePrefix}={nodeId}\"{publishingInterval}{samplingInterval} }},");
             }
         }
 

--- a/src/Helpers/PnJsonHelper.cs
+++ b/src/Helpers/PnJsonHelper.cs
@@ -22,7 +22,7 @@ public class PnJsonHelper
         sb.AppendLine(Environment.NewLine + "[");
         sb.AppendLine("  {");
         sb.AppendLine($"    \"EndpointUrl\": \"opc.tcp://{serverPath}\",");
-        sb.AppendLine("    \"UseSecurity\": false,");
+        sb.AppendLine($"    \"UseSecurity\": {(!OpcApplicationConfiguration.EnableUnsecureTransport).ToString().ToLowerInvariant()},");
         sb.AppendLine("    \"OpcNodes\": [");
 
         // Print config from plugin nodes list.

--- a/src/PluginNodes/ComplexTypeBoilerPluginNode.cs
+++ b/src/PluginNodes/ComplexTypeBoilerPluginNode.cs
@@ -1,6 +1,7 @@
 ﻿namespace OpcPlc.PluginNodes;
 
 using Opc.Ua;
+using OpcPlc.Helpers;
 using OpcPlc.PluginNodes.Models;
 using System;
 using System.Collections.Generic;
@@ -87,14 +88,15 @@ public class ComplexTypeBoilerPluginNode : IPluginNodes
 
         SetHeaterOffMethodProperties(ref heaterOffMethod);
 
+        // Get BoilerStatus complex type variable.
+        var children = new List<BaseInstanceState>();
+        _node.GetChildren(_plcNodeManager.SystemContext, children);
+
+        // Add to node list for creation of pn.json.
         Nodes = new List<NodeWithIntervals>
-            {
-                new NodeWithIntervals
-                {
-                    NodeId = "Boiler",
-                    Namespace = OpcPlc.Namespaces.OpcPlcBoiler,
-                },
-            };
+        {
+            PluginNodesHelpers.GetNodeWithIntervals(children[0].NodeId, _plcNodeManager),
+        };
     }
 
     /// <summary>

--- a/src/PluginNodes/DeterministicGuidPluginNodes.cs
+++ b/src/PluginNodes/DeterministicGuidPluginNodes.cs
@@ -73,23 +73,21 @@ public class DeterministicGuidPluginNodes : IPluginNodes
         {
             Guid id = DeterministicGuid.NewGuid();
 
-            _nodes[i] = _plcNodeManager.CreateVariableNode<uint>(
-                _plcNodeManager.CreateBaseVariable(
-                    folder,
-                    path: id,
-                    name: id.ToString(),
-                    new NodeId((uint)BuiltInType.UInt32),
-                    ValueRanks.Scalar,
-                    AccessLevels.CurrentReadOrWrite,
-                    "Constantly increasing value",
-                    NamespaceType.OpcPlcApplications,
-                    defaultValue: (uint)0));
+            BaseDataVariableState variable = _plcNodeManager.CreateBaseVariable(
+                folder,
+                path: id,
+                name: id.ToString(),
+                new NodeId((uint)BuiltInType.UInt32),
+                ValueRanks.Scalar,
+                AccessLevels.CurrentReadOrWrite,
+                "Constantly increasing value",
+                NamespaceType.OpcPlcApplications,
+                defaultValue: (uint)0);
 
-            nodes.Add(new NodeWithIntervals
-            {
-                NodeId = id.ToString(),
-                Namespace = OpcPlc.Namespaces.OpcPlcApplications,
-            });
+            _nodes[i] = _plcNodeManager.CreateVariableNode<uint>(variable);
+
+            // Add to node list for creation of pn.json.
+            nodes.Add(PluginNodesHelpers.GetNodeWithIntervals(variable.NodeId, _plcNodeManager));
         }
 
         Nodes = nodes;

--- a/src/PluginNodes/DipPluginNode.cs
+++ b/src/PluginNodes/DipPluginNode.cs
@@ -1,6 +1,7 @@
 ﻿namespace OpcPlc.PluginNodes;
 
 using Opc.Ua;
+using OpcPlc.Helpers;
 using OpcPlc.PluginNodes.Models;
 using System;
 using System.Collections.Generic;
@@ -67,25 +68,23 @@ public class DipPluginNode : IPluginNodes
 
     private void AddNodes(FolderState folder)
     {
-        _node = _plcNodeManager.CreateVariableNode<double>(
-            _plcNodeManager.CreateBaseVariable(
-                folder,
-                path: "DipData",
-                name: "DipData",
-                new NodeId((uint)BuiltInType.Double),
-                ValueRanks.Scalar,
-                AccessLevels.CurrentRead,
-                "Value with random dips",
-                NamespaceType.OpcPlcApplications));
+        BaseDataVariableState variable = _plcNodeManager.CreateBaseVariable(
+            folder,
+            path: "DipData",
+            name: "DipData",
+            new NodeId((uint)BuiltInType.Double),
+            ValueRanks.Scalar,
+            AccessLevels.CurrentRead,
+            "Value with random dips",
+            NamespaceType.OpcPlcApplications);
 
+        _node = _plcNodeManager.CreateVariableNode<double>(variable);
+
+        // Add to node list for creation of pn.json.
         Nodes = new List<NodeWithIntervals>
-            {
-                new NodeWithIntervals
-                {
-                    NodeId = "DipData",
-                    Namespace = OpcPlc.Namespaces.OpcPlcApplications,
-                },
-            };
+        {
+            PluginNodesHelpers.GetNodeWithIntervals(variable.NodeId, _plcNodeManager),
+        };
     }
 
     /// <summary>

--- a/src/PluginNodes/LongIdPluginNode.cs
+++ b/src/PluginNodes/LongIdPluginNode.cs
@@ -1,6 +1,7 @@
 ﻿namespace OpcPlc.PluginNodes;
 
 using Opc.Ua;
+using OpcPlc.Helpers;
 using OpcPlc.PluginNodes.Models;
 using System.Collections.Generic;
 using System.Text;
@@ -65,25 +66,23 @@ public class LongIdPluginNode : IPluginNodes
             id.Append((char)(65 + (i % 26)));
         }
 
-        _node = _plcNodeManager.CreateVariableNode<uint>(
-            _plcNodeManager.CreateBaseVariable(
-                folder,
-                path: id.ToString(),
-                name: "LongId3950",
-                new NodeId((uint)BuiltInType.UInt32),
-                ValueRanks.Scalar,
-                AccessLevels.CurrentReadOrWrite,
-                "Constantly increasing value",
-                NamespaceType.OpcPlcApplications,
-                defaultValue: (uint)0));
+        BaseDataVariableState variable = _plcNodeManager.CreateBaseVariable(
+            folder,
+            path: id.ToString(),
+            name: "LongId3950",
+            new NodeId((uint)BuiltInType.UInt32),
+            ValueRanks.Scalar,
+            AccessLevels.CurrentReadOrWrite,
+            "Constantly increasing value",
+            NamespaceType.OpcPlcApplications,
+            defaultValue: (uint)0);
 
+        _node = _plcNodeManager.CreateVariableNode<uint>(variable);
+
+        // Add to node list for creation of pn.json.
         Nodes = new List<NodeWithIntervals>
-            {
-                new NodeWithIntervals
-                {
-                    NodeId = id.ToString(),
-                    Namespace = OpcPlc.Namespaces.OpcPlcApplications,
-                },
-            };
+        {
+            PluginNodesHelpers.GetNodeWithIntervals(variable.NodeId, _plcNodeManager),
+        };
     }
 }

--- a/src/PluginNodes/LongStringPluginNodes.cs
+++ b/src/PluginNodes/LongStringPluginNodes.cs
@@ -19,7 +19,7 @@ public class LongStringPluginNodes : IPluginNodes
     private SimulatedVariableNode<string> _longStringIdNode50;
     private SimulatedVariableNode<byte[]> _longStringIdNode100;
     private SimulatedVariableNode<byte[]> _longStringIdNode200;
-    private readonly Random _random = new Random();
+    private readonly Random _random = new();
 
     public void AddOptions(Mono.Options.OptionSet optionSet)
     {
@@ -129,27 +129,27 @@ public class LongStringPluginNodes : IPluginNodes
                 initialByteArray));
 
         Nodes = new List<NodeWithIntervals>
+        {
+            new NodeWithIntervals
             {
-                new NodeWithIntervals
-                {
-                    NodeId = "LongString10kB",
-                    Namespace = OpcPlc.Namespaces.OpcPlcApplications,
-                },
-                new NodeWithIntervals
-                {
-                    NodeId = "LongString50kB",
-                    Namespace = OpcPlc.Namespaces.OpcPlcApplications,
-                },
-                new NodeWithIntervals
-                {
-                    NodeId = "LongString100kB",
-                    Namespace = OpcPlc.Namespaces.OpcPlcApplications,
-                },
-                new NodeWithIntervals
-                {
-                    NodeId = "LongString200kB",
-                    Namespace = OpcPlc.Namespaces.OpcPlcApplications,
-                },
-            };
+                NodeId = "LongString10kB",
+                Namespace = OpcPlc.Namespaces.OpcPlcApplications,
+            },
+            new NodeWithIntervals
+            {
+                NodeId = "LongString50kB",
+                Namespace = OpcPlc.Namespaces.OpcPlcApplications,
+            },
+            new NodeWithIntervals
+            {
+                NodeId = "LongString100kB",
+                Namespace = OpcPlc.Namespaces.OpcPlcApplications,
+            },
+            new NodeWithIntervals
+            {
+                NodeId = "LongString200kB",
+                Namespace = OpcPlc.Namespaces.OpcPlcApplications,
+            },
+        };
     }
 }

--- a/src/PluginNodes/Models/NodeWithIntervals.cs
+++ b/src/PluginNodes/Models/NodeWithIntervals.cs
@@ -3,6 +3,7 @@
 public class NodeWithIntervals
 {
     public string NodeId { get; set; }
+    public string NodeIdTypePrefix { get; set; } = "s"; // Default type is string.
     public string Namespace { get; set; }
     public uint PublishingInterval { get; set; }
     public uint SamplingInterval { get; set; }

--- a/src/PluginNodes/NegTrendPluginNode.cs
+++ b/src/PluginNodes/NegTrendPluginNode.cs
@@ -1,6 +1,7 @@
 ﻿namespace OpcPlc.PluginNodes;
 
 using Opc.Ua;
+using OpcPlc.Helpers;
 using OpcPlc.PluginNodes.Models;
 using System;
 using System.Collections.Generic;
@@ -69,25 +70,23 @@ public class NegTrendPluginNode : IPluginNodes
 
     private void AddNodes(FolderState folder)
     {
-        _node = _plcNodeManager.CreateVariableNode<double>(
-            _plcNodeManager.CreateBaseVariable(
-                folder,
-                path: "NegativeTrendData",
-                name: "NegativeTrendData",
-                new NodeId((uint)BuiltInType.Double),
-                ValueRanks.Scalar,
-                AccessLevels.CurrentRead,
-                "Value with a slow negative trend",
-                NamespaceType.OpcPlcApplications));
+        BaseDataVariableState variable = _plcNodeManager.CreateBaseVariable(
+            folder,
+            path: "NegativeTrendData",
+            name: "NegativeTrendData",
+            new NodeId((uint)BuiltInType.Double),
+            ValueRanks.Scalar,
+            AccessLevels.CurrentRead,
+            "Value with a slow negative trend",
+            NamespaceType.OpcPlcApplications);
 
+        _node = _plcNodeManager.CreateVariableNode<double>(variable);
+
+        // Add to node list for creation of pn.json.
         Nodes = new List<NodeWithIntervals>
-            {
-                new NodeWithIntervals
-                {
-                    NodeId = "NegativeTrendData",
-                    Namespace = OpcPlc.Namespaces.OpcPlcApplications,
-                },
-            };
+        {
+            PluginNodesHelpers.GetNodeWithIntervals(variable.NodeId, _plcNodeManager),
+        };
     }
 
     private void AddMethods(FolderState methodsFolder)

--- a/src/PluginNodes/OpaquePluginNode.cs
+++ b/src/PluginNodes/OpaquePluginNode.cs
@@ -1,6 +1,7 @@
 ﻿namespace OpcPlc.PluginNodes;
 
 using Opc.Ua;
+using OpcPlc.Helpers;
 using OpcPlc.PluginNodes.Models;
 using System.Collections.Generic;
 
@@ -57,25 +58,23 @@ public class OpaquePluginNode : IPluginNodes
 
     private void AddNodes(FolderState folder)
     {
-        _node = _plcNodeManager.CreateVariableNode<uint>(
-            _plcNodeManager.CreateBaseVariable(
-                folder,
-                path: new byte[] { (byte)'a', (byte)'b', (byte)'c' },
-                name: "Opaque_abc",
-                new NodeId((uint)BuiltInType.UInt32),
-                ValueRanks.Scalar,
-                AccessLevels.CurrentReadOrWrite,
-                "Constantly increasing value",
-                NamespaceType.OpcPlcApplications,
-                defaultValue: (uint)0));
+        BaseDataVariableState variable = _plcNodeManager.CreateBaseVariable(
+            folder,
+            path: new byte[] { (byte)'a', (byte)'b', (byte)'c' },
+            name: "Opaque_abc",
+            new NodeId((uint)BuiltInType.UInt32),
+            ValueRanks.Scalar,
+            AccessLevels.CurrentReadOrWrite,
+            "Constantly increasing value",
+            NamespaceType.OpcPlcApplications,
+            defaultValue: (uint)0);
 
+        _node = _plcNodeManager.CreateVariableNode<uint>(variable);
+
+        // Add to node list for creation of pn.json.
         Nodes = new List<NodeWithIntervals>
-            {
-                new NodeWithIntervals
-                {
-                    NodeId = "Opaque_abc",
-                    Namespace = OpcPlc.Namespaces.OpcPlcApplications,
-                },
-            };
+        {
+            PluginNodesHelpers.GetNodeWithIntervals(variable.NodeId, _plcNodeManager),
+        };
     }
 }

--- a/src/PluginNodes/PosTrendPluginNode.cs
+++ b/src/PluginNodes/PosTrendPluginNode.cs
@@ -1,6 +1,7 @@
 ﻿namespace OpcPlc.PluginNodes;
 
 using Opc.Ua;
+using OpcPlc.Helpers;
 using OpcPlc.PluginNodes.Models;
 using System;
 using System.Collections.Generic;
@@ -69,25 +70,23 @@ public class PosTrendPluginNode : IPluginNodes
 
     private void AddNodes(FolderState folder)
     {
-        _node = _plcNodeManager.CreateVariableNode<double>(
-            _plcNodeManager.CreateBaseVariable(
-                folder,
-                path: "PositiveTrendData",
-                name: "PositiveTrendData",
-                new NodeId((uint)BuiltInType.Double),
-                ValueRanks.Scalar,
-                AccessLevels.CurrentRead,
-                "Value with a slow positive trend",
-                NamespaceType.OpcPlcApplications));
+        BaseDataVariableState variable = _plcNodeManager.CreateBaseVariable(
+            folder,
+            path: "PositiveTrendData",
+            name: "PositiveTrendData",
+            new NodeId((uint)BuiltInType.Double),
+            ValueRanks.Scalar,
+            AccessLevels.CurrentRead,
+            "Value with a slow positive trend",
+            NamespaceType.OpcPlcApplications);
 
+        _node = _plcNodeManager.CreateVariableNode<double>(variable);
+
+        // Add to node list for creation of pn.json.
         Nodes = new List<NodeWithIntervals>
-            {
-                new NodeWithIntervals
-                {
-                    NodeId = "PositiveTrendData",
-                    Namespace = OpcPlc.Namespaces.OpcPlcApplications,
-                },
-            };
+        {
+            PluginNodesHelpers.GetNodeWithIntervals(variable.NodeId, _plcNodeManager),
+        };
     }
 
     private void AddMethods(FolderState methodsFolder)

--- a/src/PluginNodes/SpecialCharNamePluginNode.cs
+++ b/src/PluginNodes/SpecialCharNamePluginNode.cs
@@ -1,6 +1,7 @@
 ﻿namespace OpcPlc.PluginNodes;
 
 using Opc.Ua;
+using OpcPlc.Helpers;
 using OpcPlc.PluginNodes.Models;
 using System.Collections.Generic;
 using System.Web;
@@ -60,25 +61,23 @@ public class SpecialCharNamePluginNode : IPluginNodes
     {
         string SpecialChars = HttpUtility.HtmlDecode(@"&quot;!&#167;$%&amp;/()=?`&#180;\+~*&#39;#_-:.;,&lt;&gt;|@^&#176;€&#181;{[]}");
 
-        _node = _plcNodeManager.CreateVariableNode<uint>(
-            _plcNodeManager.CreateBaseVariable(
-                folder,
-                path: "Special_" + SpecialChars,
-                name: SpecialChars,
-                new NodeId((uint)BuiltInType.UInt32),
-                ValueRanks.Scalar,
-                AccessLevels.CurrentReadOrWrite,
-                "Constantly increasing value",
-                NamespaceType.OpcPlcApplications,
-                defaultValue: (uint)0));
+        BaseDataVariableState variable = _plcNodeManager.CreateBaseVariable(
+            folder,
+            path: "Special_" + SpecialChars,
+            name: SpecialChars,
+            new NodeId((uint)BuiltInType.UInt32),
+            ValueRanks.Scalar,
+            AccessLevels.CurrentReadOrWrite,
+            "Constantly increasing value",
+            NamespaceType.OpcPlcApplications,
+            defaultValue: (uint)0);
 
+        _node = _plcNodeManager.CreateVariableNode<uint>(variable);
+
+        // Add to node list for creation of pn.json.
         Nodes = new List<NodeWithIntervals>
-            {
-                new NodeWithIntervals
-                {
-                    NodeId = "Special_" + SpecialChars,
-                    Namespace = OpcPlc.Namespaces.OpcPlcApplications,
-                },
-            };
+        {
+            PluginNodesHelpers.GetNodeWithIntervals(variable.NodeId, _plcNodeManager),
+        };
     }
 }

--- a/src/PluginNodes/SpikePluginNode.cs
+++ b/src/PluginNodes/SpikePluginNode.cs
@@ -1,6 +1,7 @@
 ﻿namespace OpcPlc.PluginNodes;
 
 using Opc.Ua;
+using OpcPlc.Helpers;
 using OpcPlc.PluginNodes.Models;
 using System;
 using System.Collections.Generic;
@@ -67,25 +68,23 @@ public class SpikePluginNode : IPluginNodes
 
     private void AddNodes(FolderState folder)
     {
-        _node = _plcNodeManager.CreateVariableNode<double>(
-            _plcNodeManager.CreateBaseVariable(
-                folder,
-                path: "SpikeData",
-                name: "SpikeData",
-                new NodeId((uint)BuiltInType.Double),
-                ValueRanks.Scalar,
-                AccessLevels.CurrentRead,
-                "Value with random spikes",
-                NamespaceType.OpcPlcApplications));
+        BaseDataVariableState variable = _plcNodeManager.CreateBaseVariable(
+            folder,
+            path: "SpikeData",
+            name: "SpikeData",
+            new NodeId((uint)BuiltInType.Double),
+            ValueRanks.Scalar,
+            AccessLevels.CurrentRead,
+            "Value with random spikes",
+            NamespaceType.OpcPlcApplications);
 
+        _node = _plcNodeManager.CreateVariableNode<double>(variable);
+
+        // Add to node list for creation of pn.json.
         Nodes = new List<NodeWithIntervals>
-            {
-                new NodeWithIntervals
-                {
-                    NodeId = "SpikeData",
-                    Namespace = OpcPlc.Namespaces.OpcPlcApplications,
-                },
-            };
+        {
+            PluginNodesHelpers.GetNodeWithIntervals(variable.NodeId, _plcNodeManager),
+        };
     }
 
     /// <summary>

--- a/src/PluginNodes/UserDefinedPluginNodes.cs
+++ b/src/PluginNodes/UserDefinedPluginNodes.cs
@@ -7,6 +7,7 @@ using System.IO;
 using static OpcPlc.Program;
 using Newtonsoft.Json;
 using OpcPlc.PluginNodes.Models;
+using OpcPlc.Helpers;
 
 /// <summary>
 /// Nodes that are configuration via JSON file.
@@ -92,14 +93,10 @@ public class UserDefinedPluginNodes : IPluginNodes
             Logger.Debug($"Create node with Id '{typedNodeId}' and BrowseName '{node.Name}' in namespace with index '{_plcNodeManager.NamespaceIndexes[(int)NamespaceType.OpcPlcApplications]}'");
             CreateBaseVariable(userNodesFolder, node);
 
-            nodes.Add(new NodeWithIntervals
-            {
-                NodeId = node.NodeId.ToString(),
-                Namespace = OpcPlc.Namespaces.OpcPlcApplications,
-            });
+            nodes.Add(PluginNodesHelpers.GetNodeWithIntervals(node.NodeId, _plcNodeManager));
         }
 
-        Logger.Information("Processing node information completed.");
+        Logger.Information("Completed processing user defined node information");
 
         Nodes = nodes;
     }

--- a/src/opc-plc.csproj
+++ b/src/opc-plc.csproj
@@ -50,7 +50,7 @@
 
   <ItemGroup>
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.5.113" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.5.119" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/opc-plc-tests.csproj
+++ b/tests/opc-plc-tests.csproj
@@ -8,11 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" Version="34.0.2" />
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="FluentAssertions" Version="6.8.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Serilog.Sinks.NUnit" Version="1.0.3" />
   </ItemGroup>
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "versionHeightOffset": -1,
   "publicReleaseRefSpec": [
     "^refs/heads/main$",


### PR DESCRIPTION
Fix generated pn.json for:
* Boiler
* Deterministic GUIDs
* Opaque node

* Set UseSecurity in pn.json to true if not using `--unsecuretransport`, otherwise to false
* Update nuget packages

Example:
```
pn.json
[
  {
    "EndpointUrl": "opc.tcp://********:50000",
    "UseSecurity": false,
    "OpcNodes": [
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/Boiler;i=15013" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=StepUp" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=AlternatingBoolean" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=RandomSignedInt32" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=RandomUnsignedInt32" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;g=51b74e55-f2e3-4a4d-b79c-bf57c76ea67c" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;g=1313895e-c776-4201-b893-e514864c6692" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;g=84a537f5-3df8-4ab0-a33c-842bdeaf6cc9" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;g=c9f6d2b9-c681-4e31-9684-2014c4ec860c" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;g=20883862-eb87-4ef7-8f08-4892d74a121a" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=DipData" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt1" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt2" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt3" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt4" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt5" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=BadFastUInt1" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWX" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=LongString10kB" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=LongString50kB" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=LongString100kB" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=LongString200kB" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=NegativeTrendData" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;b=YWJj" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=PositiveTrendData" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=SlowUInt1", "OpcPublishingInterval": 10000 },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=SlowUInt2", "OpcPublishingInterval": 10000 },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=SlowUInt3", "OpcPublishingInterval": 10000 },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=SlowUInt4", "OpcPublishingInterval": 10000 },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=SlowUInt5", "OpcPublishingInterval": 10000 },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=BadSlowUInt1", "OpcPublishingInterval": 10000 },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=Special_\u0022!\u00A7$%\u0026/()=?\u0060\u00B4\\\u002B~*\u0027#_-:.;,\u003C\u003E|@^\u00B0\u20AC\u00B5{[]}" },
      { "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=SpikeData" }
    ]
  }
]
```