### PR TITLE
Enable some features by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ or if one string contains commas:
 
 Options:
       --lf, --logfile=VALUE  the filename of the logfile to use.
-                               Default: './de-lcantero-p53-plc.log'
+                               Default: './machinename-plc.log'
       --lt, --logflushtimespan=VALUE
                              the timespan in seconds when the logfile should be
                                flushed.

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Options:
                                Default: ''
       --ph, --plchostname=VALUE
                              the fully-qualified hostname of the PLC.
-                               Default: de-lcantero-p53
+                               Default: machinename
       --ol, --opcmaxstringlen=VALUE
                              the max length of a string OPC can transmit/
                                receive.

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ or if one string contains commas:
 
 Options:
       --lf, --logfile=VALUE  the filename of the logfile to use.
-                               Default: './de-lcantero-p53-plc.log'
+                               Default: './machinename-plc.log'
       --lt, --logflushtimespan=VALUE
                              the timespan in seconds when the logfile should be
                                flushed.
@@ -281,7 +281,7 @@ Options:
                                Default: ''
       --ph, --plchostname=VALUE
                              the fully-qualified hostname of the PLC.
-                               Default: de-lcantero-p53
+                               Default: machinename
       --ol, --opcmaxstringlen=VALUE
                              the max length of a string OPC can transmit/
                                receive.

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ or if one string contains commas:
 
 Options:
       --lf, --logfile=VALUE  the filename of the logfile to use.
-                               Default: './machinename-plc.log'
+                               Default: './de-lcantero-p53-plc.log'
       --lt, --logflushtimespan=VALUE
                              the timespan in seconds when the logfile should be
                                flushed.
@@ -280,10 +280,10 @@ Options:
                                endpoint.
                                Default: ''
       --ph, --plchostname=VALUE
-                             the fullqualified hostname of the plc.
-                               Default: machinename
+                             the fully-qualified hostname of the PLC.
+                               Default: de-lcantero-p53
       --ol, --opcmaxstringlen=VALUE
-                             the max length of a string opc can transmit/
+                             the max length of a string OPC can transmit/
                                receive.
                                Default: 4194304
       --lr, --ldsreginterval=VALUE
@@ -308,23 +308,23 @@ Options:
                                stored
                                Default (depends on store type):
                                X509Store: 'CurrentUser\UA_MachineDefault'
-                               Directory: 'pki/own'
+                               Directory: 'pki\own'
       --tp, --trustedcertstorepath=VALUE
                              the path of the trusted cert store
-                               Default 'pki/trusted'
+                               Default 'pki\trusted'
       --rp, --rejectedcertstorepath=VALUE
                              the path of the rejected cert store
-                               Default 'pki/rejected'
+                               Default 'pki\rejected'
       --ip, --issuercertstorepath=VALUE
                              the path of the trusted issuer cert store
-                               Default 'pki/issuer'
+                               Default 'pki\issuer'
       --csr                  show data to create a certificate signing request
                                Default 'False'
       --ab, --applicationcertbase64=VALUE
-                             update/set this applications certificate with the
+                             update/set this application's certificate with the
                                certificate passed in as bas64 string
       --af, --applicationcertfile=VALUE
-                             update/set this applications certificate with the
+                             update/set this application's certificate with the
                                certificate file specified
       --pb, --privatekeybase64=VALUE
                              initial provisioning of the application
@@ -338,20 +338,20 @@ Options:
                              the optional password for the PEM or PFX or the
                                installed application certificate
       --tb, --addtrustedcertbase64=VALUE
-                             adds the certificate to the applications trusted
+                             adds the certificate to the application's trusted
                                cert store passed in as base64 string (comma
                                separated values)
       --tf, --addtrustedcertfile=VALUE
-                             adds the certificate file(s) to the applications
+                             adds the certificate file(s) to the application's
                                trusted cert store passed in as base64 string (
                                multiple filenames supported)
       --ib, --addissuercertbase64=VALUE
                              adds the specified issuer certificate to the
-                               applications trusted issuer cert store passed in
-                               as base64 string (comma separated values)
+                               application's trusted issuer cert store passed
+                               in as base64 string (comma separated values)
       --if, --addissuercertfile=VALUE
                              adds the specified issuer certificate file(s) to
-                               the applications trusted issuer cert store (
+                               the application's trusted issuer cert store (
                                multiple filenames supported)
       --rb, --updatecrlbase64=VALUE
                              update the CRL passed in as base64 string to the
@@ -362,8 +362,8 @@ Options:
                                corresponding cert store (trusted or trusted
                                issuer)
       --rc, --removecert=VALUE
-                             remove cert(s) with the given thumbprint(s) (
-                               comma separated values)
+                             remove cert(s) with the given thumbprint(s) (comma
+                               separated values)
       --daa, --disableanonymousauth
                              flag to disable anonymous authentication.
                                Default: False
@@ -385,13 +385,6 @@ Options:
       --dc, --defaultpassword=VALUE
                              the password of the default user.
                                Default: password
-      --alm, --alarms        add alarm simulation to address space.
-                               Default: False
-      --ses, --simpleevents  add simple events simulation to address space.
-                               Default: False
-      --ref, --referencetest add reference test simulation node manager to
-                               address space.
-                               Default: False
       --dalm, --deterministicalarms=VALUE
                              add deterministic alarm simulation to address
                                space.
@@ -412,11 +405,9 @@ Options:
                                Default: 8080
       --cdn, --certdnsnames=VALUE
                              add additional DNS names or IP addresses to this
-                               application's certificate (comma separated values)
+                               application's certificate (comma separated
+                               values)
   -h, --help                 show this message and exit
-      --ctb, --complextypeboiler
-                             add complex type (boiler) to address space.
-                               Default: False
       --nv, --nodatavalues   do not generate data values
                                Default: False
       --gn, --guidnodes=VALUE
@@ -453,16 +444,8 @@ Options:
                                Default: 0
       --vfr, --veryfastrate=VALUE
                              rate in milliseconds to change fast nodes
-                               Default: 10000
-      --lid, --longid        add node with ID of 3950 chars.
-                               Default: False
-      --lsn, --longstringnodes
-                             add nodes with string values of 10/50/100/200 kB.
-                               Default: False
+                               Default: 1000
       --nn, --nonegtrend     do not generate negative trend data
-                               Default: False
-      --on, --opaquenode
-                             add node with an opaque identifier 
                                Default: False
       --np, --nopostrend     do not generate positive trend data
                                Default: False
@@ -493,9 +476,6 @@ Options:
       --ssi, --slownodesamplinginterval=VALUE
                              rate in milliseconds to sample slow nodes
                                Default: 0
-      --scn, --specialcharname
-                             add node with special characters in name 
-                               Default: False
       --ns, --nospikes       do not generate spike data
                                Default: False
       --nf, --nodesfile=VALUE

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ The tags of the container match the tags of this repository and the containers a
 
 Sample start command for Docker:
 ~~~
-docker run --rm -it -p 50000:50000 -p 8080:8080 --name opcplc mcr.microsoft.com/iotedge/opc-plc:latest --pn=50000 --autoaccept --sph --sn=5 --sr=10 --st=uint --fn=5 --fr=1 --ft=uint --ctb --scn --lid --lsn --ref --gn=5
+docker run --rm -it -p 50000:50000 -p 8080:8080 --name opcplc mcr.microsoft.com/iotedge/opc-plc:latest --pn=50000 --autoaccept --sph --sn=5 --sr=10 --st=uint --fn=5 --fr=1 --ft=uint --ref --gn=5
 ~~~
 
 Sample start command for Windows:
 ~~~
-dotnet opcplc.dll --pn=50000 --at X509Store --autoaccept --sph --sn=5 --sr=10 --st=uint --fn=5 --fr=1 --ft=uint --ctb --scn --lid --lsn --ref --gn=5
+dotnet opcplc.dll --pn=50000 --at X509Store --autoaccept --sph --sn=5 --sr=10 --st=uint --fn=5 --fr=1 --ft=uint --ref --gn=5
 ~~~
 
 Note: Make sure that your OPC UA client uses security policy `Basic256Sha256` and message security mode `Sign & Encrypt` to connect.
@@ -132,7 +132,7 @@ Additionally, you can set the configuration file name via the option `--spf`.
 
 ## Complex type (boiler)
  
-The option `--ctb` adds a simple boiler to the address space.
+Adds a simple boiler to the address space.
 
 Features:
 - BoilerStatus is a complex type that shows: temperature, pressure and heater state
@@ -181,16 +181,16 @@ More information about this feature can be found [here](deterministic-alarms.md)
 
 ## Other features
  
-- Node with special characters in name and NodeId: `--scn`
-- Node with long ID (3950 bytes): `--lid`
-- Nodes with large values (10/50 kB string, 100 kB StringArray, 200 kB ByteArray): `--lsn`
+- Node with special characters in name and NodeId:
+- Node with long ID (3950 bytes)
+- Nodes with large values (10/50 kB string, 100 kB StringArray, 200 kB ByteArray)
 - Nodes for testing all datatypes, arrays, methods, permissions, etc `--ref`. The ReferenceNodeManager of the [OPC UA .NET reference stack](https://github.com/OPCFoundation/UA-.NETStandard) is used for this purpose.
 - Limit the number of updates of Slow and Fast nodes. Update the values of the `SlowNumberOfUpdates` and `FastNumberOfUpdates` configuration nodes in the `OpcPlc/SimulatorConfiguration` folder to:
   - `< 0` (default): Slow and Fast nodes are updated indefinitely
   - `0`: Slow and Fast nodes are not updated
   - `> 0`: Slow and Fast nodes are updated the given number of times, then they stop being updated (the value of the configuration node is decremented at every update).
 - Nodes with deterministic random GUIDs as node IDs: `--gn=<number_of_nodes>`
-- Node with opaque identifier (free-format byte string): `--on`
+- Node with opaque identifier (free-format byte string)
 
 ## OPC UA Methods
 
@@ -254,7 +254,7 @@ or if one string contains commas:
 
 Options:
       --lf, --logfile=VALUE  the filename of the logfile to use.
-                               Default: './machinename-plc.log'
+                               Default: './de-lcantero-p53-plc.log'
       --lt, --logflushtimespan=VALUE
                              the timespan in seconds when the logfile should be
                                flushed.
@@ -281,7 +281,7 @@ Options:
                                Default: ''
       --ph, --plchostname=VALUE
                              the fully-qualified hostname of the PLC.
-                               Default: machinename
+                               Default: de-lcantero-p53
       --ol, --opcmaxstringlen=VALUE
                              the max length of a string OPC can transmit/
                                receive.
@@ -385,6 +385,10 @@ Options:
       --dc, --defaultpassword=VALUE
                              the password of the default user.
                                Default: password
+      --alm, --alarms        add alarm simulation to address space.
+                               Default: False
+      --ses, --simpleevents  add simple events simulation to address space.
+                               Default: False
       --dalm, --deterministicalarms=VALUE
                              add deterministic alarm simulation to address
                                space.

--- a/src/CliOptions.cs
+++ b/src/CliOptions.cs
@@ -186,9 +186,6 @@ public class CliOptions
                 { "dc|defaultpassword=", $"the password of the default user.\nDefault: {Program.DefaultPassword}", (string s) => Program.DefaultPassword = s ?? Program.DefaultPassword},
 
                 // Special nodes
-                { "alm|alarms", $"add alarm simulation to address space.\nDefault: {AddAlarmSimulation}", (string s) => AddAlarmSimulation = s != null },
-                { "ses|simpleevents", $"add simple events simulation to address space.\nDefault: {AddSimpleEventsSimulation}", (string s) => AddSimpleEventsSimulation = s != null },
-                { "ref|referencetest", $"add reference test simulation node manager to address space.\nDefault: {AddReferenceTestSimulation}", (string s) => AddReferenceTestSimulation = s != null },
                 { "dalm|deterministicalarms=", $"add deterministic alarm simulation to address space.\nProvide a script file for controlling deterministic alarms.", (string s) => DeterministicAlarmSimulationFile = s },
 
                 // misc

--- a/src/CliOptions.cs
+++ b/src/CliOptions.cs
@@ -186,6 +186,8 @@ public class CliOptions
                 { "dc|defaultpassword=", $"the password of the default user.\nDefault: {Program.DefaultPassword}", (string s) => Program.DefaultPassword = s ?? Program.DefaultPassword},
 
                 // Special nodes
+                { "alm|alarms", $"add alarm simulation to address space.\nDefault: {AddAlarmSimulation}", (string s) => AddAlarmSimulation = s != null },
+                { "ses|simpleevents", $"add simple events simulation to address space.\nDefault: {AddSimpleEventsSimulation}", (string s) => AddSimpleEventsSimulation = s != null },
                 { "dalm|deterministicalarms=", $"add deterministic alarm simulation to address space.\nProvide a script file for controlling deterministic alarms.", (string s) => DeterministicAlarmSimulationFile = s },
 
                 // misc

--- a/src/PlcSimulation.cs
+++ b/src/PlcSimulation.cs
@@ -9,9 +9,18 @@ public class PlcSimulation
     /// <summary>
     /// Flags for node generation.
     /// </summary>
-    public static bool AddAlarmSimulation { get; set; }
-    public static bool AddSimpleEventsSimulation { get; set; }
-    public static bool AddReferenceTestSimulation { get; set; }
+
+    // alm|alarms
+    // add alarm simulation to address space.
+    public static bool AddAlarmSimulation { get; set; } = true;
+
+    // ses|simpleevents
+    // Add simple events simulation to address space.
+    public static bool AddSimpleEventsSimulation { get; set; } = true;
+
+    // ref|referencetest
+    // Add reference test simulation node manager to address space.
+    public static bool AddReferenceTestSimulation { get; set; } = true;
     public static string DeterministicAlarmSimulationFile { get; set; }
 
     public static uint EventInstanceCount { get; set; } = 0;

--- a/src/PlcSimulation.cs
+++ b/src/PlcSimulation.cs
@@ -12,11 +12,11 @@ public class PlcSimulation
 
     // alm|alarms
     // add alarm simulation to address space.
-    public static bool AddAlarmSimulation { get; set; } = true;
+    public static bool AddAlarmSimulation { get; set; }
 
     // ses|simpleevents
     // Add simple events simulation to address space.
-    public static bool AddSimpleEventsSimulation { get; set; } = true;
+    public static bool AddSimpleEventsSimulation { get; set; }
 
     // ref|referencetest
     // Add reference test simulation node manager to address space.

--- a/src/PluginNodes/ComplexTypeBoilerPluginNode.cs
+++ b/src/PluginNodes/ComplexTypeBoilerPluginNode.cs
@@ -23,10 +23,9 @@ public class ComplexTypeBoilerPluginNode : IPluginNodes
 
     public void AddOptions(Mono.Options.OptionSet optionSet)
     {
-        optionSet.Add(
-            "ctb|complextypeboiler",
-            $"add complex type (boiler) to address space.\nDefault: {_isEnabled}",
-            (string s) => _isEnabled = s != null);
+        // ctb|complextypeboiler
+        // Add complex type (boiler) to address space.
+        _isEnabled = true;
     }
 
     public void AddToAddressSpace(FolderState telemetryFolder, FolderState methodsFolder, PlcNodeManager plcNodeManager)

--- a/src/PluginNodes/LongIdPluginNode.cs
+++ b/src/PluginNodes/LongIdPluginNode.cs
@@ -19,10 +19,9 @@ public class LongIdPluginNode : IPluginNodes
 
     public void AddOptions(Mono.Options.OptionSet optionSet)
     {
-        optionSet.Add(
-            "lid|longid",
-            $"add node with ID of 3950 chars.\nDefault: {_isEnabled}",
-            (string s) => _isEnabled = s != null);
+        // lid|longid
+        // Add node with ID of 3950 chars.
+        _isEnabled = true;
     }
 
     public void AddToAddressSpace(FolderState telemetryFolder, FolderState methodsFolder, PlcNodeManager plcNodeManager)

--- a/src/PluginNodes/LongStringPluginNodes.cs
+++ b/src/PluginNodes/LongStringPluginNodes.cs
@@ -23,10 +23,9 @@ public class LongStringPluginNodes : IPluginNodes
 
     public void AddOptions(Mono.Options.OptionSet optionSet)
     {
-        optionSet.Add(
-            "lsn|longstringnodes",
-            $"add nodes with string values of 10/50/100/200 kB.\nDefault: {_isEnabled}",
-            (string s) => _isEnabled = s != null);
+        // lsn|longstringnodes
+        // Add nodes with string values of 10/50/100/200 kB.
+        _isEnabled = true;
     }
 
     public void AddToAddressSpace(FolderState telemetryFolder, FolderState methodsFolder, PlcNodeManager plcNodeManager)

--- a/src/PluginNodes/OpaquePluginNode.cs
+++ b/src/PluginNodes/OpaquePluginNode.cs
@@ -18,10 +18,9 @@ public class OpaquePluginNode : IPluginNodes
 
     public void AddOptions(Mono.Options.OptionSet optionSet)
     {
-        optionSet.Add(
-            "on|opaquenode",
-            $"add node with an opaque identifier.\nDefault: {_isEnabled}",
-            (string s) => _isEnabled = s != null);
+        // on|opaquenode
+        // Add node with an opaque identifier.
+        _isEnabled = true;
     }
 
     public void AddToAddressSpace(FolderState telemetryFolder, FolderState methodsFolder, PlcNodeManager plcNodeManager)

--- a/src/PluginNodes/SpecialCharNamePluginNode.cs
+++ b/src/PluginNodes/SpecialCharNamePluginNode.cs
@@ -19,10 +19,9 @@ public class SpecialCharNamePluginNode : IPluginNodes
 
     public void AddOptions(Mono.Options.OptionSet optionSet)
     {
-        optionSet.Add(
-            "scn|specialcharname",
-            $"add node with special characters in name.\nDefault: {_isEnabled}",
-            (string s) => _isEnabled = s != null);
+        // scn|specialcharname
+        // Add node with special characters in name.
+        _isEnabled = true;
     }
 
     public void AddToAddressSpace(FolderState telemetryFolder, FolderState methodsFolder, PlcNodeManager plcNodeManager)

--- a/src/PluginNodes/UserDefinedPluginNodes.cs
+++ b/src/PluginNodes/UserDefinedPluginNodes.cs
@@ -1,13 +1,13 @@
 ﻿namespace OpcPlc.PluginNodes;
 
+using Newtonsoft.Json;
 using Opc.Ua;
+using OpcPlc.Helpers;
+using OpcPlc.PluginNodes.Models;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using static OpcPlc.Program;
-using Newtonsoft.Json;
-using OpcPlc.PluginNodes.Models;
-using OpcPlc.Helpers;
 
 /// <summary>
 /// Nodes that are configuration via JSON file.
@@ -90,10 +90,14 @@ public class UserDefinedPluginNodes : IPluginNodes
                 node.Description = node.Name;
             }
 
-            Logger.Debug($"Create node with Id '{typedNodeId}' and BrowseName '{node.Name}' in namespace with index '{_plcNodeManager.NamespaceIndexes[(int)NamespaceType.OpcPlcApplications]}'");
+            Logger.Debug("Create node with Id {typedNodeId} and BrowseName {name} in namespace with index {namespaceIndex}",
+                typedNodeId,
+                node.Name,
+                _plcNodeManager.NamespaceIndexes[(int)NamespaceType.OpcPlcApplications]);
+
             CreateBaseVariable(userNodesFolder, node);
 
-            nodes.Add(PluginNodesHelpers.GetNodeWithIntervals(node.NodeId, _plcNodeManager));
+            nodes.Add(PluginNodesHelpers.GetNodeWithIntervals((NodeId)node.NodeId, _plcNodeManager));
         }
 
         Logger.Information("Completed processing user defined node information");

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -152,7 +152,7 @@ public static class Program
         // Validate and parse extra arguments
         if (extraArgs.Count > 0)
         {
-            Logger.Warning($"Found one or more invalid command line arguments: {string.Join(" ", args)}");
+            Logger.Warning($"Found one or more invalid command line arguments: {string.Join(" ", extraArgs)}");
             CliOptions.PrintUsage(options);
         }
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -152,9 +152,8 @@ public static class Program
         // Validate and parse extra arguments
         if (extraArgs.Count > 0)
         {
-            Logger.Error($"Error with command line arguments: {string.Join(" ", args)}");
+            Logger.Warning($"Found one or more invalid command line arguments: {string.Join(" ", args)}");
             CliOptions.PrintUsage(options);
-            return;
         }
 
         LogLogo();

--- a/tests/DeterministicAlarmsTests.cs
+++ b/tests/DeterministicAlarmsTests.cs
@@ -48,7 +48,7 @@ public class DeterministicAlarmsTests : SubscriptionTestsBase
         NodeShouldHaveStates(lightOff2, Inactive, Disabled);
 
         var waitUntilStartInSeconds = FromSeconds(9); // value in dalm001.json file
-        FireTimersWithPeriodAndReceiveEvents(waitUntilStartInSeconds, 1)
+        FireTimersWithPeriodAndReceiveEvents(waitUntilStartInSeconds, expectedCount: 1)
             .First()
             .Should().Contain(new Dictionary<string, object>
             {
@@ -67,7 +67,7 @@ public class DeterministicAlarmsTests : SubscriptionTestsBase
 
         AdvanceToNextStep();
 
-        FireTimersWithPeriodAndReceiveEvents(FromSeconds(5), 1)
+        FireTimersWithPeriodAndReceiveEvents(FromSeconds(5), expectedCount: 1)
             .First()
             .Should().Contain(new Dictionary<string, object>
             {
@@ -83,7 +83,7 @@ public class DeterministicAlarmsTests : SubscriptionTestsBase
 
         AdvanceToNextStep();
 
-        FireTimersWithPeriodAndReceiveEvents(FromSeconds(7), 1)
+        FireTimersWithPeriodAndReceiveEvents(FromSeconds(7), expectedCount: 1)
             .First()
             .Should().Contain(new Dictionary<string, object>
             {
@@ -99,7 +99,7 @@ public class DeterministicAlarmsTests : SubscriptionTestsBase
 
         AdvanceToNextStep();
 
-        FireTimersWithPeriodAndReceiveEvents(FromSeconds(4), 1)
+        FireTimersWithPeriodAndReceiveEvents(FromSeconds(4), expectedCount: 1)
             .First()
             .Should().Contain(new Dictionary<string, object>
             {
@@ -113,7 +113,7 @@ public class DeterministicAlarmsTests : SubscriptionTestsBase
 
         NodeShouldHaveStates(tempHigh1, Active, Enabled);
 
-        FireTimersWithPeriodAndReceiveEvents(FromMilliseconds(1), 1)
+        FireTimersWithPeriodAndReceiveEvents(FromMilliseconds(1), expectedCount: 1)
             .First()
             .Should().Contain(new Dictionary<string, object>
             {
@@ -125,7 +125,7 @@ public class DeterministicAlarmsTests : SubscriptionTestsBase
 
         AdvanceToNextStep();
 
-        FireTimersWithPeriodAndReceiveEvents(FromSeconds(5), 1)
+        FireTimersWithPeriodAndReceiveEvents(FromSeconds(5), expectedCount: 1)
             .First()
             .Should().Contain(new Dictionary<string, object>
             {
@@ -138,7 +138,7 @@ public class DeterministicAlarmsTests : SubscriptionTestsBase
         AdvanceToNextStep();
 
         // At this point, the *runningForSeconds* limit in the JSON file causes execution to stop
-        FireTimersWithPeriodAndReceiveEvents(FromSeconds(1), 0);
+        FireTimersWithPeriodAndReceiveEvents(FromSeconds(1), expectedCount: 0);
 
         NodeShouldHaveStates(doorOpen1, Active, Enabled);
         NodeShouldHaveStates(tempHigh1, Active, Enabled);

--- a/tests/DeterministicAlarmsTests2.cs
+++ b/tests/DeterministicAlarmsTests2.cs
@@ -1,11 +1,10 @@
 namespace OpcPlc.Tests;
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
 using Opc.Ua;
+using System;
+using System.Linq;
 using static System.TimeSpan;
 
 [TestFixture]
@@ -42,14 +41,14 @@ public class DeterministicAlarmsTests2 : SubscriptionTestsBase
         NodeShouldHaveStates(doorOpen1, Inactive, Disabled);
 
         var waitUntilStartInSeconds = FromSeconds(5); // value in dalm002.json file
-        var opcEvent1 = FireTimersWithPeriodAndReceiveEvents(waitUntilStartInSeconds, 1).First();
+        var opcEvent1 = FireTimersWithPeriodAndReceiveEvents(waitUntilStartInSeconds, expectedCount: 1).First();
         var timeForFirstEvent = DateTime.Parse(opcEvent1["/Time"].ToString());
 
         NodeShouldHaveStates(doorOpen1, Active, Enabled);
 
         AdvanceToNextStep();
 
-        var opcEvent2 = FireTimersWithPeriodAndReceiveEvents(waitUntilStartInSeconds, 1).First();
+        var opcEvent2 = FireTimersWithPeriodAndReceiveEvents(waitUntilStartInSeconds, expectedCount: 1).First();
         var timeForNextEvent = DateTime.Parse(opcEvent2["/Time"].ToString());
 
         NodeShouldHaveStates(doorOpen1, Inactive, Disabled);

--- a/tests/MonitoringTestsBase.cs
+++ b/tests/MonitoringTestsBase.cs
@@ -1,16 +1,16 @@
 namespace OpcPlc.Tests;
 
+using FluentAssertions;
+using NUnit.Framework;
+using Opc.Ua;
+using Opc.Ua.Client;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using System.Text;
-using FluentAssertions;
-using NUnit.Framework;
-using Opc.Ua;
-using Opc.Ua.Client;
+using System.Threading;
 
 /// <summary>
 /// Abstract base class for tests using OPC-UA Subscriptions.
@@ -134,7 +134,7 @@ public abstract class SubscriptionTestsBase : SimulatorTestsBase
 
     protected IEnumerable<Dictionary<string, object>> FireTimersWithPeriodAndReceiveEvents(TimeSpan period, int expectedCount)
     {
-        FireTimersWithPeriod(period, 1);
+        FireTimersWithPeriod(period, numberOfTimes: 1);
         return ReceiveEventsAsDictionary(expectedCount);
     }
 

--- a/tests/PlcSimulatorFixture.Config.xml
+++ b/tests/PlcSimulatorFixture.Config.xml
@@ -4,107 +4,107 @@
     xmlns:ua="http://opcfoundation.org/UA/2008/02/Types.xsd"
     xmlns="http://opcfoundation.org/UA/SDK/Configuration.xsd"
     schemaLocation="./Schema/ApplicationConfiguration.xsd">
-    <ApplicationName>PlcSimulatorFixture</ApplicationName>
-    <ApplicationUri>urn:localhost:Microsoft:PlcSimulatorFixture</ApplicationUri>
-    <ProductUri>http://opcfoundation.org/UA/PlcSimulatorFixture</ProductUri>
-    <ApplicationType>Client_1</ApplicationType>
+  <ApplicationName>PlcSimulatorFixture</ApplicationName>
+  <ApplicationUri>urn:localhost:Microsoft:PlcSimulatorFixture</ApplicationUri>
+  <ProductUri>http://opcfoundation.org/UA/PlcSimulatorFixture</ProductUri>
+  <ApplicationType>Client_1</ApplicationType>
 
-    <SecurityConfiguration>
+  <SecurityConfiguration>
 
-        <!-- Where the application instance certificate is stored (MachineDefault) -->
-        <ApplicationCertificate>
-            <StoreType>X509Store</StoreType>
-            <StorePath>CurrentUser\My</StorePath>
-            <SubjectName>CN=PlcSimulatorFixture, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
-        </ApplicationCertificate>
+    <!-- Where the application instance certificate is stored (MachineDefault) -->
+    <ApplicationCertificate>
+      <StoreType>X509Store</StoreType>
+      <StorePath>CurrentUser\My</StorePath>
+      <SubjectName>CN=PlcSimulatorFixture, C=US, S=Arizona, O=OPC Foundation, DC=localhost</SubjectName>
+    </ApplicationCertificate>
 
-        <!-- Where the issuer certificate are stored (certificate authorities) -->
-        <TrustedIssuerCertificates>
-            <StoreType>Directory</StoreType>
-            <StorePath>%LocalApplicationData%/OPC Foundation/pki/issuer</StorePath>
-        </TrustedIssuerCertificates>
+    <!-- Where the issuer certificate are stored (certificate authorities) -->
+    <TrustedIssuerCertificates>
+      <StoreType>Directory</StoreType>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/issuer</StorePath>
+    </TrustedIssuerCertificates>
 
-        <!-- Where the trust list is stored (UA Applications) -->
-        <TrustedPeerCertificates>
-            <StoreType>Directory</StoreType>
-            <StorePath>%LocalApplicationData%/OPC Foundation/pki/trusted</StorePath>
-        </TrustedPeerCertificates>
+    <!-- Where the trust list is stored (UA Applications) -->
+    <TrustedPeerCertificates>
+      <StoreType>Directory</StoreType>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/trusted</StorePath>
+    </TrustedPeerCertificates>
 
-        <!-- The directory used to store invalid certficates for later review by the administrator. -->
-        <RejectedCertificateStore>
-            <StoreType>Directory</StoreType>
-            <StorePath>%LocalApplicationData%/OPC Foundation/pki/rejected</StorePath>
-        </RejectedCertificateStore>
+    <!-- The directory used to store invalid certficates for later review by the administrator. -->
+    <RejectedCertificateStore>
+      <StoreType>Directory</StoreType>
+      <StorePath>%LocalApplicationData%/OPC Foundation/pki/rejected</StorePath>
+    </RejectedCertificateStore>
 
-        <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used
+    <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used
     for easy debugging purposes ONLY and turned off for production deployments! -->
-        <AutoAcceptUntrustedCertificates>false</AutoAcceptUntrustedCertificates>
+    <AutoAcceptUntrustedCertificates>false</AutoAcceptUntrustedCertificates>
 
-    </SecurityConfiguration>
+  </SecurityConfiguration>
 
-    <TransportConfigurations />
+  <TransportConfigurations />
 
-    <TransportQuotas>
-        <OperationTimeout>600000</OperationTimeout>
-        <MaxStringLength>1048576</MaxStringLength>
-        <MaxByteStringLength>4194304</MaxByteStringLength>
-        <MaxArrayLength>65535</MaxArrayLength>
-        <MaxMessageSize>4194304</MaxMessageSize>
-        <MaxBufferSize>65535</MaxBufferSize>
-        <ChannelLifetime>300000</ChannelLifetime>
-        <SecurityTokenLifetime>3600000</SecurityTokenLifetime>
-    </TransportQuotas>
+  <TransportQuotas>
+    <OperationTimeout>600000</OperationTimeout>
+    <MaxStringLength>1048576</MaxStringLength>
+    <MaxByteStringLength>4194304</MaxByteStringLength>
+    <MaxArrayLength>65535</MaxArrayLength>
+    <MaxMessageSize>4194304</MaxMessageSize>
+    <MaxBufferSize>65535</MaxBufferSize>
+    <ChannelLifetime>300000</ChannelLifetime>
+    <SecurityTokenLifetime>3600000</SecurityTokenLifetime>
+  </TransportQuotas>
 
-    <!-- This element is only required for Client and ClientServer applications -->
-    <ClientConfiguration>
+  <!-- This element is only required for Client and ClientServer applications -->
+  <ClientConfiguration>
 
-        <!-- The default timeout for new sessions -->
-        <DefaultSessionTimeout>600000</DefaultSessionTimeout>
+    <!-- The default timeout for new sessions -->
+    <DefaultSessionTimeout>600000</DefaultSessionTimeout>
 
-        <!-- The well-known URLs for the local discovery servers
+    <!-- The well-known URLs for the local discovery servers
          URLs are tested in the order they appear in this list. -->
-        <WellKnownDiscoveryUrls>
-            <ua:String>opc.tcp://{0}:4840/UADiscovery</ua:String>
-        </WellKnownDiscoveryUrls>
+    <WellKnownDiscoveryUrls>
+      <ua:String>opc.tcp://{0}:4840/UADiscovery</ua:String>
+    </WellKnownDiscoveryUrls>
 
-        <!-- EndpointDescriptions for system wide discovery servers -->
-        <DiscoveryServers></DiscoveryServers>
+    <!-- EndpointDescriptions for system wide discovery servers -->
+    <DiscoveryServers></DiscoveryServers>
 
-        <!-- The minimum subscription lifetime.
+    <!-- The minimum subscription lifetime.
       This ensures subscriptions are not set to expire too quickly. The requesed lifetime count
       and keep alive count are calculated using this value and the request publishing interval -->
-        <MinSubscriptionLifetime>10000</MinSubscriptionLifetime>
+    <MinSubscriptionLifetime>10000</MinSubscriptionLifetime>
 
-        <ReverseConnect>
-            <ClientEndpoints>
-                <ClientEndpoint>
-                    <!--<EndpointUrl>opc.tcp://localhost:65300</EndpointUrl>-->
-                </ClientEndpoint>
-            </ClientEndpoints>
-            <HoldTime>15000</HoldTime>
-            <WaitTimeout>20000</WaitTimeout>
-        </ReverseConnect>
+    <ReverseConnect>
+      <ClientEndpoints>
+        <ClientEndpoint>
+          <!--<EndpointUrl>opc.tcp://localhost:65300</EndpointUrl>-->
+        </ClientEndpoint>
+      </ClientEndpoints>
+      <HoldTime>15000</HoldTime>
+      <WaitTimeout>20000</WaitTimeout>
+    </ReverseConnect>
 
-    </ClientConfiguration>
+  </ClientConfiguration>
 
-    <TraceConfiguration>
-        <OutputFilePath>%LocalApplicationData%/Logs/Opc.Ua.PlcSimulatorFixture.log.txt</OutputFilePath>
-        <DeleteOnLoad>true</DeleteOnLoad>
-        <!-- Show Only Errors -->
-        <!-- <TraceMasks>1</TraceMasks> -->
-        <!-- Show Only Security and Errors -->
-        <!-- <TraceMasks>513</TraceMasks> -->
-        <!-- Show Only Security, Errors and Trace -->
-        <!-- <TraceMasks>515</TraceMasks> -->
-        <!-- Show Only Security, COM Calls, Errors and Trace -->
-        <!-- <TraceMasks>771</TraceMasks> -->
-        <!-- Show Only Security, Service Calls, Errors and Trace -->
-        <!-- <TraceMasks>523</TraceMasks> -->
-        <!-- Show Only Security, ServiceResultExceptions, Errors and Trace -->
-        <!-- <TraceMasks>519</TraceMasks> -->
-    </TraceConfiguration>
+  <TraceConfiguration>
+    <OutputFilePath>%LocalApplicationData%/Logs/Opc.Ua.PlcSimulatorFixture.log.txt</OutputFilePath>
+    <DeleteOnLoad>true</DeleteOnLoad>
+    <!-- Show Only Errors -->
+    <!-- <TraceMasks>1</TraceMasks> -->
+    <!-- Show Only Security and Errors -->
+    <!-- <TraceMasks>513</TraceMasks> -->
+    <!-- Show Only Security, Errors and Trace -->
+    <!-- <TraceMasks>515</TraceMasks> -->
+    <!-- Show Only Security, COM Calls, Errors and Trace -->
+    <!-- <TraceMasks>771</TraceMasks> -->
+    <!-- Show Only Security, Service Calls, Errors and Trace -->
+    <!-- <TraceMasks>523</TraceMasks> -->
+    <!-- Show Only Security, ServiceResultExceptions, Errors and Trace -->
+    <!-- <TraceMasks>519</TraceMasks> -->
+  </TraceConfiguration>
 
-    <!-- Disables the hi-res clock if the QueryPerformanceCounter does work on a particular machine. -->
-    <DisableHiResClock>true</DisableHiResClock>
+  <!-- Disables the hi-res clock if the QueryPerformanceCounter does work on a particular machine. -->
+  <DisableHiResClock>true</DisableHiResClock>
 
 </ApplicationConfiguration>

--- a/tests/PlcSimulatorFixture.cs
+++ b/tests/PlcSimulatorFixture.cs
@@ -167,6 +167,9 @@ public class PlcSimulatorFixture
     {
         _log.WriteLine("Create a session with OPC UA server");
         var userIdentity = new UserIdentity(new AnonymousIdentityToken());
+
+        // When unit test certificate expires,
+        // remove the pki folder from \tests\bin\<CONFIG>\<ARCH>
         return Session.Create(_config, _serverEndpoint, updateBeforeConnect: false, sessionName, sessionTimeout: 60000, userIdentity, preferredLocales: null);
     }
 

--- a/tests/PlcSimulatorFixture.cs
+++ b/tests/PlcSimulatorFixture.cs
@@ -1,5 +1,13 @@
 namespace OpcPlc.Tests;
 
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Opc.Ua;
+using Opc.Ua.Client;
+using Opc.Ua.Configuration;
+using OpcPlc;
+using Serilog;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -11,14 +19,6 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
-using FluentAssertions;
-using Moq;
-using NUnit.Framework;
-using Opc.Ua;
-using Opc.Ua.Client;
-using Opc.Ua.Configuration;
-using OpcPlc;
-using Serilog;
 
 /// <summary>
 /// A test fixture that starts a static singleton instance of the OPC PLC simulator.
@@ -97,6 +97,7 @@ public class PlcSimulatorFixture
                 _timers.Add((timer, handler));
                 return timer;
             });
+
         mock.Setup(f => f.NewFastTimer(It.IsAny<FastTimerElapsedEventHandler>(), It.IsAny<uint>()))
             .Returns((FastTimerElapsedEventHandler handler, uint intervalInMilliseconds) =>
             {
@@ -109,6 +110,7 @@ public class PlcSimulatorFixture
                 _fastTimers.Add((timer, handler));
                 return timer;
             });
+
         Program.TimeService = mock.Object;
 
         mock.Setup(f => f.Now())
@@ -132,7 +134,7 @@ public class PlcSimulatorFixture
                 _serverCancellationTokenSource.Token)
             .GetAwaiter().GetResult());
 
-        var endpointUrl = WaitForServerUp();
+        string endpointUrl = WaitForServerUp();
         await _log.WriteAsync($"Found server at: {endpointUrl}");
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
@@ -163,9 +165,9 @@ public class PlcSimulatorFixture
     /// <returns>The created session.</returns>
     public Task<Session> CreateSessionAsync(string sessionName)
     {
-        _log.WriteLine("Create a session with OPC UA server.");
+        _log.WriteLine("Create a session with OPC UA server");
         var userIdentity = new UserIdentity(new AnonymousIdentityToken());
-        return Session.Create(_config, _serverEndpoint, false, sessionName, 60000, userIdentity, null);
+        return Session.Create(_config, _serverEndpoint, updateBeforeConnect: false, sessionName, sessionTimeout: 60000, userIdentity, preferredLocales: null);
     }
 
     /// <summary>
@@ -228,10 +230,10 @@ public class PlcSimulatorFixture
         };
 
         // load the application configuration.
-        var config = await application.LoadApplicationConfiguration(false).ConfigureAwait(false);
+        var config = await application.LoadApplicationConfiguration(silent: false).ConfigureAwait(false);
 
         // check the application certificate.
-        var haveAppCertificate = await application.CheckApplicationInstanceCertificate(false, 0).ConfigureAwait(false);
+        bool haveAppCertificate = await application.CheckApplicationInstanceCertificate(silent: false, minimumKeySize: 0).ConfigureAwait(false);
         if (!haveAppCertificate)
         {
             throw new Exception("Application instance certificate invalid!");

--- a/tests/SimulatorTestsBase.cs
+++ b/tests/SimulatorTestsBase.cs
@@ -1,14 +1,14 @@
 namespace OpcPlc.Tests;
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Bogus;
 using FluentAssertions;
 using NUnit.Framework;
 using Opc.Ua;
 using Opc.Ua.Client;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 /// <summary>
 /// Abstract base class for simulator integration tests.

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "versionHeightOffset": -1,
   "publicReleaseRefSpec": [
     "^refs/heads/main$",


### PR DESCRIPTION
* Enable some features by default: complextypeboiler (--ctb), longid (--lid), longstringnodes (--lsn), opaquenode (--on), specialcharname (--scn), referencetest
* Remove default features from command line arguments list
* When invalid args specified, warn instead of fail