### PR TITLE
Adds nested folder structure and guid node id support to user node configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ Here's a sample node configuration file:
 ~~~
 {
   "Folder": "MyTelemetry",
+  "FolderList": [    
+    {
+      "Folder": "Directory",
+      "NodeList": [        
+        {
+          "NodeId": "ChildNode"
+        },
+      ]
+    }
+  ],
   "NodeList": [
     {
       "NodeId": 1023,
@@ -93,6 +103,7 @@ Here's a sample node configuration file:
 }
 ~~~
 - Folder: Defines the name of the folder under which the user specified nodes should be created. This folder is created below the root of the OPC UA server.
+- FolderList: Defines the list of child folders, which will be published by the emulated server. (Optional)
 - NodeList: Defines the list of nodes, which will be published by the emulated server. Nodes specified in the list can be browsed and changed by OPC UA applications. This enables developers to easyly implement and test OPC UA client applications.
 - NodeId: Specifies the identifier of the node and is required. This value can be a decimal or string value. Every other JSON type is converted to a string identifier.
 - Name: The display name of the tag. If not set it will be set to the NodeId. (Optional)

--- a/src/ConfigNode.cs
+++ b/src/ConfigNode.cs
@@ -11,6 +11,8 @@ public class ConfigFolder
 {
     public string Folder { get; set; }
 
+    public List<ConfigFolder> FolderList { get; set; }
+
     public List<ConfigNode> NodeList { get; set; }
 }
 

--- a/src/PlcNodeManager.cs
+++ b/src/PlcNodeManager.cs
@@ -185,11 +185,6 @@ public class PlcNodeManager : CustomNodeManager2
             baseDataVariableState.NodeId = new NodeId(path, namespaceIndex);
             baseDataVariableState.BrowseName = new QualifiedName(path, namespaceIndex);
         }
-        else if (path is Guid)
-        {
-            baseDataVariableState.NodeId = new NodeId((Guid)path, namespaceIndex);
-            baseDataVariableState.BrowseName = new QualifiedName(((Guid)path).ToString(), namespaceIndex);
-        }
         else
         {
             Logger.Debug("NodeId type is {nodeIdType}", path.GetType().ToString());

--- a/src/PlcNodeManager.cs
+++ b/src/PlcNodeManager.cs
@@ -185,6 +185,11 @@ public class PlcNodeManager : CustomNodeManager2
             baseDataVariableState.NodeId = new NodeId(path, namespaceIndex);
             baseDataVariableState.BrowseName = new QualifiedName(path, namespaceIndex);
         }
+        else if (path is Guid)
+        {
+            baseDataVariableState.NodeId = new NodeId((Guid)path, namespaceIndex);
+            baseDataVariableState.BrowseName = new QualifiedName(((Guid)path).ToString(), namespaceIndex);
+        }
         else
         {
             Logger.Debug("NodeId type is {nodeIdType}", path.GetType().ToString());

--- a/src/nodesfile.json
+++ b/src/nodesfile.json
@@ -1,5 +1,22 @@
 {
   "Folder": "MyTelemetry",
+  "FolderList": [
+    {      
+      "Folder": "Child",
+      "NodeList": [
+        {
+          "NodeId": 9999,
+          "Name": "Child Node",
+          "Description": "Child Node for testing"
+        },
+        {
+          "NodeId": "c6522393-5ca1-4547-9551-29d110ca4a3f",
+          "Name": "Guid",
+          "Description": "Guid test"
+        }
+      ]
+    }
+  ],
   "NodeList": [
     {
       "NodeId": 1023,


### PR DESCRIPTION
Adds nested folder structure support to user node configuration
Adds guid node id support to user node configuration

## Purpose
* Users can create a nested node structures for testing purposes.
* Users can create nodes with a guid node id type for testing purposes.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

Might break for users that have an existing user node configuration with a guid node id but expect it to be of node id type string.

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code and run with `--nf nodesfile.json`

## What to Check
Verify that the following are valid
* Verify that `MyTelemetry` folder has a child folder called "Child"
* Verify that `Child` folder has two variable nodes (`Child Node` and `Guid`)
* Verify that `Guid` variable node has a node id of guid (`g=c6522393-5ca1-4547-9551-29d110ca4a3f`)

## Other Information
If needed I can also split the PR into one for guid support and one for nested folder support.