### PR TITLE
update path for certificate persistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ docker build -f .\src\bin\publish\Release\linux-x64\Dockerfile.linux-amd64 -t io
 X.509 certificates:
 
 * Running on Windows natively, you cannot use an application certificate store of type `Directory`, since the access to the private key will fail. Use the option `--at X509Store` in this case.
-* Running as Linux Docker container, you can map the certificate stores to the host file system by using the Docker run option `-v <hostdirectory>:/appdata`. This will make the certificate persistent over starts.
+* Running as Linux Docker container, you can map the certificate stores to the host file system by using the Docker run option `-v <hostdirectory>:/app/pki`. This will make the certificate persistent over starts.
 * Running as Linux Docker container using an X509Store for the application certificate, you need to use the Docker run option `-v x509certstores:/root/.dotnet/corefx/cryptography/x509stores` and the application option `--at X509Store`
 
 ## Resources


### PR DESCRIPTION
Folder /appdata does not exist in the container image. it's `/app` and the cert folder is `pki`.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* the default container app folder in docker file is `/app`, not `/appdata` , moreover the default main pki folder is `pki`

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* run the container image with the `-v` podman/docker option for pki persistency and observe that server certificate is located in /app/pki

## What to Check

The default WORKDIR here: <https://github.com/Azure-Samples/iot-edge-opc-plc/blob/main/tools/scripts/docker-source.ps1#L172> is `/app`

## Other Information
<!-- Add any other helpful information that may be needed here. -->