### PR TITLE
Specify event source

### DIFF
--- a/src/PluginNodes/Boiler2PluginNodes.cs
+++ b/src/PluginNodes/Boiler2PluginNodes.cs
@@ -247,17 +247,17 @@ public class Boiler2PluginNodes : IPluginNodes
 
         // Init the events.
         _failureEv.Initialize(_plcNodeManager.SystemContext,
-            source: null,
+            source: _currentTempDegreesNode,
             EventSeverity.Max,
             new LocalizedText($"Temperature is above or equal to overheat threshold!"));
 
         _checkFunctionEv.Initialize(_plcNodeManager.SystemContext,
-            source: null,
+            source: _currentTempDegreesNode,
             EventSeverity.Low,
             new LocalizedText($"Temperature is above target!"));
 
         _offSpecEv.Initialize(_plcNodeManager.SystemContext,
-            source: null,
+            source: _currentTempDegreesNode,
             EventSeverity.MediumLow,
             new LocalizedText($"Temperature is off spec!"));
 

--- a/src/PluginNodes/Boiler2PluginNodes.cs
+++ b/src/PluginNodes/Boiler2PluginNodes.cs
@@ -245,26 +245,26 @@ public class Boiler2PluginNodes : IPluginNodes
         _offSpecEv = new DeviceHealthDiagnosticAlarmTypeState(parent: null);
         _maintenanceRequiredEv = new DeviceHealthDiagnosticAlarmTypeState(parent: null);
 
-        // Init the events
+        // Init the events.
         _failureEv.Initialize(_plcNodeManager.SystemContext,
-                    source: null,
-                    EventSeverity.Max,
-                    new LocalizedText($"Temperature is above overheat threshold!"));
+            source: null,
+            EventSeverity.Max,
+            new LocalizedText($"Temperature is above overheat threshold!"));
 
         _checkFunctionEv.Initialize(_plcNodeManager.SystemContext,
-                    source: null,
-                    EventSeverity.Low,
-                    new LocalizedText($"Temperature is above target!"));
+            source: null,
+            EventSeverity.Low,
+            new LocalizedText($"Temperature is above target!"));
 
         _offSpecEv.Initialize(_plcNodeManager.SystemContext,
-                    source: null,
-                    EventSeverity.MediumLow,
-                    new LocalizedText($"Temperature is off spec!"));
+            source: null,
+            EventSeverity.MediumLow,
+            new LocalizedText($"Temperature is off spec!"));
 
         _maintenanceRequiredEv.Initialize(_plcNodeManager.SystemContext,
-                    source: null,
-                    EventSeverity.Medium,
-                    new LocalizedText($"Maintenance required!"));
+            source: null,
+            EventSeverity.Medium,
+            new LocalizedText($"Maintenance required!"));
 
         _failureEv.SetChildValue(_plcNodeManager.SystemContext, Opc.Ua.BrowseNames.SourceName, value: "Overheated", copy: false);
         _checkFunctionEv.SetChildValue(_plcNodeManager.SystemContext, Opc.Ua.BrowseNames.SourceName, value: "Check function", copy: false);

--- a/src/PluginNodes/Boiler2PluginNodes.cs
+++ b/src/PluginNodes/Boiler2PluginNodes.cs
@@ -249,7 +249,7 @@ public class Boiler2PluginNodes : IPluginNodes
         _failureEv.Initialize(_plcNodeManager.SystemContext,
             source: null,
             EventSeverity.Max,
-            new LocalizedText($"Temperature is above overheat threshold!"));
+            new LocalizedText($"Temperature is above or equal to overheat threshold!"));
 
         _checkFunctionEv.Initialize(_plcNodeManager.SystemContext,
             source: null,

--- a/src/PluginNodes/Boiler2PluginNodes.cs
+++ b/src/PluginNodes/Boiler2PluginNodes.cs
@@ -249,7 +249,7 @@ public class Boiler2PluginNodes : IPluginNodes
         _failureEv.Initialize(_plcNodeManager.SystemContext,
             source: _currentTempDegreesNode,
             EventSeverity.Max,
-            new LocalizedText($"Temperature is above or equal to overheat threshold!"));
+            new LocalizedText($"Temperature is above or equal to the overheat threshold!"));
 
         _checkFunctionEv.Initialize(_plcNodeManager.SystemContext,
             source: _currentTempDegreesNode,

--- a/tests/Boiler2DeviceHealthEventsTests.cs
+++ b/tests/Boiler2DeviceHealthEventsTests.cs
@@ -96,7 +96,7 @@ public class Boiler2DeviceHealthEventsTests : SubscriptionTestsBase
                 });
                 value.Should().ContainKey("/Message")
                     .WhoseValue.Should().BeOfType<LocalizedText>()
-                    .Which.Text.Should().Be("Temperature is above or equal to overheat threshold!");
+                    .Which.Text.Should().Be("Temperature is above or equal to the overheat threshold!");
             }
         }
     }

--- a/tests/Boiler2DeviceHealthEventsTests.cs
+++ b/tests/Boiler2DeviceHealthEventsTests.cs
@@ -96,7 +96,7 @@ public class Boiler2DeviceHealthEventsTests : SubscriptionTestsBase
                 });
                 value.Should().ContainKey("/Message")
                     .WhoseValue.Should().BeOfType<LocalizedText>()
-                    .Which.Text.Should().Be("Temperature is above overheat threshold!");
+                    .Which.Text.Should().Be("Temperature is above or equal to overheat threshold!");
             }
         }
     }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.9.6",
+  "version": "2.9.7",
   "versionHeightOffset": -1,
   "publicReleaseRefSpec": [
     "^refs/heads/main$",


### PR DESCRIPTION
* Set current temp node as source for temp-related events
* Keep null as source for maintenance event

[Spec](https://reference.opcfoundation.org/Core/Part5/v104/docs/6.4.2): If the Event is not specific to a Node the NodeId is set to null.