### PR TITLE
enable flat directory certificate store for k8s cert-manager compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ X.509 certificates:
 * Running on Windows natively, you cannot use an application certificate store of type `Directory`, since the access to the private key will fail. Use the option `--at X509Store` in this case.
 * Running as Linux Docker container, you can map the certificate stores to the host file system by using the Docker run option `-v <hostpkidirectory>:/app/pki`. This will make the certificate persistent over starts.
 * Running as Linux Docker container using an X509Store for the application certificate, you need to use the Docker run option `-v x509certstores:/root/.dotnet/corefx/cryptography/x509stores` and the application option `--at X509Store`
-* When running in kubernetes context, use option `--at FlatDirectory`. This enables the OPC UA server to consume both public key and private key certificates directly from the /app/pki/own/ path without expecting the `certs` and `private` subdirectories. furthermore, certificates with .crt and .key are accepted.
+* When running in kubernetes context, use option `--at FlatDirectory`. This enables the OPC UA server to consume both public key and private key certificates directly from the /app/pki/own/ path without expecting the `certs` and `private` subdirectories. Furthermore, certificates of type .crt and .key are accepted.
 
 ## Resources
 - [The OPC Foundation OPC UA .NET reference stack](https://github.com/OPCFoundation/UA-.NETStandard)

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ X.509 certificates:
 * Running on Windows natively, you cannot use an application certificate store of type `Directory`, since the access to the private key will fail. Use the option `--at X509Store` in this case.
 * Running as Linux Docker container, you can map the certificate stores to the host file system by using the Docker run option `-v <hostpkidirectory>:/app/pki`. This will make the certificate persistent over starts.
 * Running as Linux Docker container using an X509Store for the application certificate, you need to use the Docker run option `-v x509certstores:/root/.dotnet/corefx/cryptography/x509stores` and the application option `--at X509Store`
+* When running in kubernetes context, use option `--at FlatDirectory`. This enables the OPC UA server to consume both public key and private key certificates directly from the /app/pki/own/ path without expecting the `certs` and `private` subdirectories. furthermore, certificates with .crt and .key are accepted.
 
 ## Resources
 - [The OPC Foundation OPC UA .NET reference stack](https://github.com/OPCFoundation/UA-.NETStandard)
@@ -357,7 +358,7 @@ Options:
                                Default: 2000
       --at, --appcertstoretype=VALUE
                              the own application cert store type.
-                               (allowed values: Directory, X509Store)
+                               (allowed values: Directory, X509Store, FlatDirectory)
                                Default: 'Directory'
       --ap, --appcertstorepath=VALUE
                              the path where the own application cert should be
@@ -365,6 +366,7 @@ Options:
                                Default (depends on store type):
                                X509Store: 'CurrentUser\UA_MachineDefault'
                                Directory: 'pki\own'
+                               FlatDirectory: 'pki\own'
       --tp, --trustedcertstorepath=VALUE
                              the path of the trusted cert store.
                                Default 'pki\trusted'

--- a/src/CliOptions.cs
+++ b/src/CliOptions.cs
@@ -3,6 +3,7 @@ namespace OpcPlc;
 using Microsoft.Extensions.Logging;
 using Mono.Options;
 using Opc.Ua;
+using OpcPlc.Certs;
 using OpcPlc.Helpers;
 using System;
 using System.Collections.Generic;
@@ -94,21 +95,31 @@ public class CliOptions
 
             // cert store options
             { "at|appcertstoretype=", $"the own application cert store type. \n(allowed values: Directory, X509Store)\nDefault: '{OpcOwnCertStoreType}'", (string s) => {
-                    if (s.Equals(CertificateStoreType.X509Store, StringComparison.OrdinalIgnoreCase) || s.Equals(CertificateStoreType.Directory, StringComparison.OrdinalIgnoreCase))
+                    switch (s)
                     {
-                        OpcOwnCertStoreType = s.Equals(CertificateStoreType.X509Store, StringComparison.OrdinalIgnoreCase) ? CertificateStoreType.X509Store : CertificateStoreType.Directory;
-                        OpcOwnCertStorePath = s.Equals(CertificateStoreType.X509Store, StringComparison.OrdinalIgnoreCase) ? OpcOwnCertX509StorePathDefault : OpcOwnCertDirectoryStorePathDefault;
-                    }
-                    else
-                    {
-                        throw new OptionException();
+                        case CertificateStoreType.X509Store:
+                            OpcOwnCertStoreType = CertificateStoreType.X509Store;
+                            OpcOwnCertStorePath = OpcOwnCertX509StorePathDefault;
+                            break;
+                        case CertificateStoreType.Directory:
+                            OpcOwnCertStoreType = CertificateStoreType.Directory;
+                            OpcOwnCertStorePath = OpcOwnCertDirectoryStorePathDefault;
+                            break;
+                        case FlatDirectoryCertificateStore.StoreTypeName:
+                            OpcOwnCertStoreType = FlatDirectoryCertificateStore.StoreTypeName;
+                            OpcOwnCertStorePath = OpcOwnCertDirectoryStorePathDefault;
+                            break;
+                        default:
+                            throw new OptionException();
                     }
                 }
             },
 
             { "ap|appcertstorepath=", "the path where the own application cert should be stored\nDefault (depends on store type):\n" +
                     $"X509Store: '{OpcOwnCertX509StorePathDefault}'\n" +
-                    $"Directory: '{OpcOwnCertDirectoryStorePathDefault}'", (string s) => OpcOwnCertStorePath = s
+                    $"Directory: '{OpcOwnCertDirectoryStorePathDefault}'" +
+                    $"FlatDirectory: '{OpcOwnCertDirectoryStorePathDefault}'",
+                    (string s) => OpcOwnCertStorePath = s
             },
 
             { "tp|trustedcertstorepath=", $"the path of the trusted cert store.\nDefault '{OpcTrustedCertDirectoryStorePathDefault}'", (string s) => OpcTrustedCertStorePath = s },

--- a/src/FlatDirectoryCertificateStore.cs
+++ b/src/FlatDirectoryCertificateStore.cs
@@ -1,0 +1,233 @@
+namespace OpcPlc.Certs;
+
+using Opc.Ua;
+using Opc.Ua.Security.Certificates;
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Flat directory certificate store that does not have internal
+/// hierarchy with certs/crl/private subdirectories.
+/// </summary>
+public sealed class FlatDirectoryCertificateStore : ICertificateStore
+{
+    private const string CrtExtension = ".crt";
+    private const string KeyExtension = ".key";
+
+    private readonly DirectoryCertificateStore _innerStore;
+
+    /// <summary>
+    /// Identifier for flat directory certificate store.
+    /// </summary>
+    public const string StoreTypeName = "FlatDirectory";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FlatDirectoryCertificateStore"/> class.
+    /// </summary>
+    public FlatDirectoryCertificateStore()
+    {
+        _innerStore = new DirectoryCertificateStore(noSubDirs: true);
+    }
+
+    /// <inheritdoc/>
+    public string StoreType => StoreTypeName;
+
+    /// <inheritdoc/>
+    public string StorePath => _innerStore.StorePath;
+
+    /// <inheritdoc/>
+    public bool SupportsLoadPrivateKey => _innerStore.SupportsLoadPrivateKey;
+
+    /// <inheritdoc/>
+    public bool SupportsCRLs => _innerStore.SupportsCRLs;
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _innerStore.Dispose();
+    }
+
+    /// <inheritdoc/>
+    public void Open(string location, bool noPrivateKeys = true)
+    {
+        ArgumentNullException.ThrowIfNull(location);
+        _innerStore.Open(location, noPrivateKeys);
+    }
+
+    /// <inheritdoc/>
+    public void Close()
+    {
+        _innerStore.Close();
+    }
+
+    /// <inheritdoc/>
+    public Task Add(X509Certificate2 certificate, string password = null)
+    {
+        return _innerStore.Add(certificate, password);
+    }
+
+    /// <inheritdoc/>
+    public Task<bool> Delete(string thumbprint)
+    {
+        return _innerStore.Delete(thumbprint);
+    }
+
+    /// <inheritdoc/>
+    public async Task<X509Certificate2Collection> Enumerate()
+    {
+        var certificatesCollection = await _innerStore.Enumerate().ConfigureAwait(false);
+        if (!_innerStore.Directory.Exists)
+        {
+            return certificatesCollection;
+        }
+
+        foreach (FileInfo file in _innerStore.Directory.GetFiles('*' + CrtExtension))
+        {
+            try
+            {
+                X509Certificate2Collection certificates = new X509Certificate2Collection();
+                certificates.ImportFromPemFile(file.FullName);
+                certificatesCollection.AddRange(certificates);
+                foreach (X509Certificate2 certificate in certificates)
+                {
+                    Utils.LogInfo("Enumerate certificates - certificate added {0}", certificate.Thumbprint);
+                }
+            }
+            catch (Exception e)
+            {
+                Utils.LogError(e, "Could not load certificate from file: {0}", file.FullName);
+            }
+        }
+
+        return certificatesCollection;
+    }
+
+    /// <inheritdoc/>
+    public Task AddCRL(X509CRL crl)
+    {
+        return _innerStore.AddCRL(crl);
+    }
+
+    /// <inheritdoc/>
+    public Task<bool> DeleteCRL(X509CRL crl)
+    {
+        return _innerStore.DeleteCRL(crl);
+    }
+
+    /// <inheritdoc/>
+    public Task<X509CRLCollection> EnumerateCRLs()
+    {
+        return _innerStore.EnumerateCRLs();
+    }
+
+    /// <inheritdoc/>
+    public Task<X509CRLCollection> EnumerateCRLs(X509Certificate2 issuer, bool validateUpdateTime = true)
+    {
+        return _innerStore.EnumerateCRLs(issuer, validateUpdateTime);
+    }
+
+    /// <inheritdoc/>
+    public async Task<X509Certificate2Collection> FindByThumbprint(string thumbprint)
+    {
+        var certificatesCollection = await _innerStore.FindByThumbprint(thumbprint).ConfigureAwait(false);
+
+        if (!_innerStore.Directory.Exists)
+        {
+            return certificatesCollection;
+        }
+
+        foreach (FileInfo file in _innerStore.Directory.GetFiles('*' + CrtExtension))
+        {
+            try
+            {
+                X509Certificate2Collection certificates = new X509Certificate2Collection();
+                certificates.ImportFromPemFile(file.FullName);
+                foreach (X509Certificate2 certificate in certificates)
+                {
+                    if (string.Equals(certificate.Thumbprint, thumbprint, StringComparison.OrdinalIgnoreCase))
+                    {
+                        Utils.LogInfo("Find by thumbprint: {0} - found", thumbprint);
+                        certificatesCollection.Add(certificate);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Utils.LogError(e, "Could not load certificate from file: {0}", file.FullName);
+            }
+        }
+
+        return certificatesCollection;
+    }
+
+    /// <inheritdoc/>
+    public Task<StatusCode> IsRevoked(X509Certificate2 issuer, X509Certificate2 certificate)
+    {
+        return _innerStore.IsRevoked(issuer, certificate);
+    }
+
+    /// <inheritdoc/>
+    public async Task<X509Certificate2> LoadPrivateKey(string thumbprint, string subjectName, string password)
+    {
+        if (!_innerStore.Directory.Exists)
+        {
+            return await _innerStore.LoadPrivateKey(thumbprint, subjectName, password).ConfigureAwait(false);
+        }
+
+        foreach (FileInfo file in _innerStore.Directory.GetFiles('*' + CrtExtension))
+        {
+            try
+            {
+                FileInfo keyFile = new FileInfo(file.FullName.Replace(CrtExtension, KeyExtension, StringComparison.OrdinalIgnoreCase));
+                if (keyFile.Exists)
+                {
+                    using X509Certificate2 certificate = new X509Certificate2(file.FullName);
+                    if (!MatchCertificate(certificate, thumbprint, subjectName))
+                    {
+                        continue;
+                    }
+
+                    X509Certificate2 privateKeyCertificate = X509Certificate2.CreateFromPemFile(file.FullName, keyFile.FullName);
+
+                    Utils.LogInfo("Loading private key succeeded for {0} - {1}", thumbprint, subjectName);
+                    return privateKeyCertificate;
+                }
+            }
+            catch (Exception e)
+            {
+                Utils.LogError(e, "Could not load private key for certificate file: {0}", file.FullName);
+            }
+        }
+
+        return await _innerStore.LoadPrivateKey(thumbprint, subjectName, password).ConfigureAwait(false);
+    }
+
+    private bool MatchCertificate(X509Certificate2 certificate, string thumbprint, string subjectName)
+    {
+        if (!string.IsNullOrEmpty(thumbprint) &&
+            !string.Equals(certificate.Thumbprint, thumbprint, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(subjectName) &&
+            !X509Utils.CompareDistinguishedName(subjectName, certificate.Subject) &&
+            (
+                subjectName.Contains('=', StringComparison.OrdinalIgnoreCase) ||
+                !X509Utils.ParseDistinguishedName(certificate.Subject).Any(s => s.Equals("CN=" + subjectName, StringComparison.Ordinal))))
+        {
+            return false;
+        }
+
+        // skip if not RSA certificate
+        if (X509Utils.GetRSAPublicKeySize(certificate) < 0)
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/FlatDirectoryCertificateStore.cs
+++ b/src/FlatDirectoryCertificateStore.cs
@@ -78,7 +78,7 @@ public sealed class FlatDirectoryCertificateStore : ICertificateStore
     /// <inheritdoc/>
     public async Task<X509Certificate2Collection> Enumerate()
     {
-        var certificatesCollection = await _innerStore.Enumerate().ConfigureAwait(false);
+        X509Certificate2Collection certificatesCollection = await _innerStore.Enumerate().ConfigureAwait(false);
         if (!_innerStore.Directory.Exists)
         {
             return certificatesCollection;
@@ -88,17 +88,17 @@ public sealed class FlatDirectoryCertificateStore : ICertificateStore
         {
             try
             {
-                X509Certificate2Collection certificates = new X509Certificate2Collection();
+                var certificates = new X509Certificate2Collection();
                 certificates.ImportFromPemFile(file.FullName);
                 certificatesCollection.AddRange(certificates);
                 foreach (X509Certificate2 certificate in certificates)
                 {
-                    Utils.LogInfo("Enumerate certificates - certificate added {0}", certificate.Thumbprint);
+                    Utils.LogInfo("Enumerate certificates - certificate added {thumbprint}", certificate.Thumbprint);
                 }
             }
             catch (Exception e)
             {
-                Utils.LogError(e, "Could not load certificate from file: {0}", file.FullName);
+                Utils.LogError(e, "Could not load certificate from file: {fileName}", file.FullName);
             }
         }
 
@@ -132,7 +132,7 @@ public sealed class FlatDirectoryCertificateStore : ICertificateStore
     /// <inheritdoc/>
     public async Task<X509Certificate2Collection> FindByThumbprint(string thumbprint)
     {
-        var certificatesCollection = await _innerStore.FindByThumbprint(thumbprint).ConfigureAwait(false);
+        X509Certificate2Collection certificatesCollection = await _innerStore.FindByThumbprint(thumbprint).ConfigureAwait(false);
 
         if (!_innerStore.Directory.Exists)
         {
@@ -143,20 +143,20 @@ public sealed class FlatDirectoryCertificateStore : ICertificateStore
         {
             try
             {
-                X509Certificate2Collection certificates = new X509Certificate2Collection();
+                var certificates = new X509Certificate2Collection();
                 certificates.ImportFromPemFile(file.FullName);
                 foreach (X509Certificate2 certificate in certificates)
                 {
                     if (string.Equals(certificate.Thumbprint, thumbprint, StringComparison.OrdinalIgnoreCase))
                     {
-                        Utils.LogInfo("Find by thumbprint: {0} - found", thumbprint);
+                        Utils.LogInfo("Find by thumbprint: {thumbprint} - found", thumbprint);
                         certificatesCollection.Add(certificate);
                     }
                 }
             }
             catch (Exception e)
             {
-                Utils.LogError(e, "Could not load certificate from file: {0}", file.FullName);
+                Utils.LogError(e, "Could not load certificate from file: {fileName}", file.FullName);
             }
         }
 
@@ -181,10 +181,10 @@ public sealed class FlatDirectoryCertificateStore : ICertificateStore
         {
             try
             {
-                FileInfo keyFile = new FileInfo(file.FullName.Replace(CrtExtension, KeyExtension, StringComparison.OrdinalIgnoreCase));
+                var keyFile = new FileInfo(file.FullName.Replace(CrtExtension, KeyExtension, StringComparison.OrdinalIgnoreCase));
                 if (keyFile.Exists)
                 {
-                    using X509Certificate2 certificate = new X509Certificate2(file.FullName);
+                    using var certificate = new X509Certificate2(file.FullName);
                     if (!MatchCertificate(certificate, thumbprint, subjectName))
                     {
                         continue;
@@ -192,13 +192,13 @@ public sealed class FlatDirectoryCertificateStore : ICertificateStore
 
                     X509Certificate2 privateKeyCertificate = X509Certificate2.CreateFromPemFile(file.FullName, keyFile.FullName);
 
-                    Utils.LogInfo("Loading private key succeeded for {0} - {1}", thumbprint, subjectName);
+                    Utils.LogInfo("Loading private key succeeded for {thumbprint} - {subjectName}", thumbprint, subjectName);
                     return privateKeyCertificate;
                 }
             }
             catch (Exception e)
             {
-                Utils.LogError(e, "Could not load private key for certificate file: {0}", file.FullName);
+                Utils.LogError(e, "Could not load private key for certificate file: {fileName}", file.FullName);
             }
         }
 

--- a/src/FlatDirectoryCertificateStoreType.cs
+++ b/src/FlatDirectoryCertificateStoreType.cs
@@ -1,0 +1,21 @@
+namespace OpcPlc.Certs;
+
+using Opc.Ua;
+
+/// <summary>
+/// Defines type for <see cref="FlatDirectoryCertificateStore"/>.
+/// </summary>
+public sealed class FlatDirectoryCertificateStoreType : ICertificateStoreType
+{
+    /// <inheritdoc/>
+    public ICertificateStore CreateStore()
+    {
+        return new FlatDirectoryCertificateStore();
+    }
+
+    /// <inheritdoc/>
+    public bool SupportsStorePath(string storePath)
+    {
+        return !string.IsNullOrEmpty(storePath);
+    }
+}

--- a/src/OpcApplicationConfiguration.cs
+++ b/src/OpcApplicationConfiguration.cs
@@ -3,6 +3,7 @@ namespace OpcPlc;
 using Microsoft.Extensions.Logging;
 using Opc.Ua;
 using Opc.Ua.Configuration;
+using OpcPlc.Certs;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -58,10 +59,29 @@ public partial class OpcApplicationConfiguration
     public static int OpcMaxStringLength { get; set; } = 4 * 1024 * 1024;
 
     /// <summary>
+    /// Set when a flat directory certificate store should be used.
+    /// </summary>
+    public static bool EnableFlatDirectoryCertStore { get; set; } = false;
+
+    /// <summary>
+    /// the flat directory certificate store shall only be initialized once
+    /// </summary>
+    private static bool _flatDirectoryCertStoreInitialized = false;
+
+    /// <summary>
     /// Configures all OPC stack settings.
     /// </summary>
     public async Task<ApplicationConfiguration> ConfigureAsync()
     {
+        if (!_flatDirectoryCertStoreInitialized)
+        {
+            // Register FlatDirectoryCertificateStoreType as knows certificate store type.
+            CertificateStoreType.RegisterCertificateStoreType(
+                FlatDirectoryCertificateStore.StoreTypeName,
+                new FlatDirectoryCertificateStoreType());
+            _flatDirectoryCertStoreInitialized = true;
+        }
+
         // instead of using a configuration XML file, configure everything programmatically
         var application = new ApplicationInstance
         {

--- a/src/OpcApplicationConfiguration.cs
+++ b/src/OpcApplicationConfiguration.cs
@@ -64,7 +64,7 @@ public partial class OpcApplicationConfiguration
     public static bool EnableFlatDirectoryCertStore { get; set; } = false;
 
     /// <summary>
-    /// the flat directory certificate store shall only be initialized once
+    /// The flat directory certificate store shall only be initialized once
     /// </summary>
     private static bool _flatDirectoryCertStoreInitialized = false;
 
@@ -75,7 +75,7 @@ public partial class OpcApplicationConfiguration
     {
         if (!_flatDirectoryCertStoreInitialized)
         {
-            // Register FlatDirectoryCertificateStoreType as knows certificate store type.
+            // Register FlatDirectoryCertificateStoreType as known certificate store type.
             CertificateStoreType.RegisterCertificateStoreType(
                 FlatDirectoryCertificateStore.StoreTypeName,
                 new FlatDirectoryCertificateStoreType());

--- a/src/OpcApplicationConfigurationSecurity.cs
+++ b/src/OpcApplicationConfigurationSecurity.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Opc.Ua;
 using Opc.Ua.Configuration;
 using Opc.Ua.Security.Certificates;
+using OpcPlc.Certs;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -114,15 +115,24 @@ public partial class OpcApplicationConfiguration
         securityConfiguration.ApplicationCertificate.StorePath = OpcOwnCertStorePath;
 
         // configure trusted issuer certificates store
-        securityConfiguration.TrustedIssuerCertificates.StoreType = OpcOwnCertStoreType;
+        securityConfiguration.TrustedIssuerCertificates.StoreType =
+            OpcOwnCertStoreType == FlatDirectoryCertificateStore.StoreTypeName
+                ? FlatDirectoryCertificateStore.StoreTypeName
+                : CertificateStoreType.Directory;
         securityConfiguration.TrustedIssuerCertificates.StorePath = OpcIssuerCertStorePath;
 
         // configure trusted peer certificates store
-        securityConfiguration.TrustedPeerCertificates.StoreType = OpcOwnCertStoreType;
+        securityConfiguration.TrustedPeerCertificates.StoreType =
+            OpcOwnCertStoreType == FlatDirectoryCertificateStore.StoreTypeName
+                ? FlatDirectoryCertificateStore.StoreTypeName
+                : CertificateStoreType.Directory;
         securityConfiguration.TrustedPeerCertificates.StorePath = OpcTrustedCertStorePath;
 
         // configure rejected certificates store
-        securityConfiguration.RejectedCertificateStore.StoreType = OpcOwnCertStoreType;
+        securityConfiguration.RejectedCertificateStore.StoreType = 
+        OpcOwnCertStoreType == FlatDirectoryCertificateStore.StoreTypeName
+            ? FlatDirectoryCertificateStore.StoreTypeName
+            : CertificateStoreType.Directory;
         securityConfiguration.RejectedCertificateStore.StorePath = OpcRejectedCertStorePath;
 
         ApplicationConfiguration = await options.Create().ConfigureAwait(false);

--- a/src/OpcApplicationConfigurationSecurity.cs
+++ b/src/OpcApplicationConfigurationSecurity.cs
@@ -1,4 +1,4 @@
-﻿namespace OpcPlc;
+namespace OpcPlc;
 
 using Microsoft.Extensions.Logging;
 using Opc.Ua;
@@ -110,40 +110,25 @@ public partial class OpcApplicationConfiguration
             .SetAddAppCertToTrustedStore(TrustMyself);
 
         var securityConfiguration = ApplicationConfiguration.SecurityConfiguration;
-        var id = securityConfiguration.ApplicationCertificate;
-        if (!id.StorePath.Equals(OpcOwnCertStorePath, StringComparison.OrdinalIgnoreCase))
-        {
-            id.StoreType = OpcOwnCertStoreType;
-            id.StorePath = OpcOwnCertStorePath;
-        }
+        securityConfiguration.ApplicationCertificate.StoreType = OpcOwnCertStoreType;
+        securityConfiguration.ApplicationCertificate.StorePath = OpcOwnCertStorePath;
 
         // configure trusted issuer certificates store
-        var issuerList = securityConfiguration.TrustedIssuerCertificates;
-        if (issuerList.StorePath != OpcIssuerCertStorePath)
-        {
-            issuerList.StoreType = CertificateStoreType.Directory;
-            issuerList.StorePath = OpcIssuerCertStorePath;
-        }
+        securityConfiguration.TrustedIssuerCertificates.StoreType = OpcOwnCertStoreType;
+        securityConfiguration.TrustedIssuerCertificates.StorePath = OpcIssuerCertStorePath;
 
         // configure trusted peer certificates store
-        var trustList = securityConfiguration.TrustedPeerCertificates;
-        if (trustList.StorePath != OpcTrustedCertStorePath)
-        {
-            trustList.StoreType = CertificateStoreType.Directory;
-            trustList.StorePath = OpcTrustedCertStorePath;
-        }
+        securityConfiguration.TrustedPeerCertificates.StoreType = OpcOwnCertStoreType;
+        securityConfiguration.TrustedPeerCertificates.StorePath = OpcTrustedCertStorePath;
 
         // configure rejected certificates store
-        var rejectedStore = securityConfiguration.RejectedCertificateStore;
-        if (rejectedStore.StorePath != OpcRejectedCertStorePath)
-        {
-            rejectedStore.StoreType = CertificateStoreType.Directory;
-            rejectedStore.StorePath = OpcRejectedCertStorePath;
-        }
+        securityConfiguration.RejectedCertificateStore.StoreType = OpcOwnCertStoreType;
+        securityConfiguration.RejectedCertificateStore.StorePath = OpcRejectedCertStorePath;
+
         ApplicationConfiguration = await options.Create().ConfigureAwait(false);
 
-        Logger.LogInformation("Application Certificate store type is: {storeType}", id.StoreType);
-        Logger.LogInformation("Application Certificate store path is: {storePath}", id.StorePath);
+        Logger.LogInformation("Application Certificate store type is: {storeType}", securityConfiguration.ApplicationCertificate.StoreType);
+        Logger.LogInformation("Application Certificate store path is: {storePath}", securityConfiguration.ApplicationCertificate.StorePath);
 
         Logger.LogInformation("Rejection of SHA1 signed certificates is {status}",
             securityConfiguration.RejectSHA1SignedCertificates ? "enabled" : "disabled");
@@ -151,14 +136,14 @@ public partial class OpcApplicationConfiguration
         Logger.LogInformation("Minimum certificate key size set to {minimumCertificateKeySize}",
             securityConfiguration.MinimumCertificateKeySize);
 
-        Logger.LogInformation("Trusted Issuer store type is: {storeType}", issuerList.StoreType);
-        Logger.LogInformation("Trusted Issuer Certificate store path is: {storePath}", issuerList.StorePath);
+        Logger.LogInformation("Trusted Issuer store type is: {storeType}", securityConfiguration.TrustedIssuerCertificates.StoreType);
+        Logger.LogInformation("Trusted Issuer Certificate store path is: {storePath}", securityConfiguration.TrustedIssuerCertificates.StorePath);
 
-        Logger.LogInformation("Trusted Peer Certificate store type is: {storeType}", trustList.StoreType);
-        Logger.LogInformation("Trusted Peer Certificate store path is: {storePath}", trustList.StorePath);
+        Logger.LogInformation("Trusted Peer Certificate store type is: {storeType}", securityConfiguration.TrustedPeerCertificates.StoreType);
+        Logger.LogInformation("Trusted Peer Certificate store path is: {storePath}", securityConfiguration.TrustedPeerCertificates.StorePath);
 
-        Logger.LogInformation("Rejected certificate store type is: {storeType}", rejectedStore.StoreType);
-        Logger.LogInformation("Rejected Certificate store path is: {storePath}", rejectedStore.StorePath);
+        Logger.LogInformation("Rejected certificate store type is: {storeType}", securityConfiguration.RejectedCertificateStore.StoreType);
+        Logger.LogInformation("Rejected Certificate store path is: {storePath}", securityConfiguration.RejectedCertificateStore.StorePath);
 
         // handle cert validation
         if (AutoAcceptCerts)

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "versionHeightOffset": -1,
   "publicReleaseRefSpec": [
     "^refs/heads/main$",


### PR DESCRIPTION
## Purpose
* add support for flat directory certificate store for k8s cert manager compatibility
* handle .crt and .key certificate types

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->