### PR TITLE
Do not add custom types into global EncodeableFactory

### DIFF
--- a/src/PlcServer.cs
+++ b/src/PlcServer.cs
@@ -18,7 +18,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Threading;
-
 using Meters = OpcPlc.MetricsConfig;
 
 public partial class PlcServer : StandardServer
@@ -262,9 +261,14 @@ public partial class PlcServer : StandardServer
     {
         var nodeManagers = new List<INodeManager>();
 
+        var x = typeof(StandardServer).GetField("m_serverInternal", BindingFlags.Instance | BindingFlags.NonPublic);
+        var y = x.FieldType.GetField("m_factory", BindingFlags.Instance | BindingFlags.NonPublic);
+        y.SetValue(server, new EncodeableFactory(false));
+
         // Add encodable complex types.
+
         server.Factory.AddEncodeableTypes(Assembly.GetExecutingAssembly());
-        EncodeableFactory.GlobalFactory.AddEncodeableTypes(Assembly.GetExecutingAssembly());
+        // EncodeableFactory.GlobalFactory.AddEncodeableTypes(Assembly.GetExecutingAssembly());
 
         // Add DI node manager first so that it gets the namespace index 2.
         var diNodeManager = new DiNodeManager(server, configuration);
@@ -425,6 +429,7 @@ public partial class PlcServer : StandardServer
             if (currentSessions.Count > 0)
             {
                 // provide some time for the connected clients to detect the shutdown state.
+#pragma warning disable CS0618 // Type or member is obsolete
                 ServerInternal.Status.Value.ShutdownReason = new LocalizedText(string.Empty, "Application closed."); // Invariant.
                 ServerInternal.Status.Variable.ShutdownReason.Value = new LocalizedText(string.Empty, "Application closed."); // Invariant.
                 ServerInternal.Status.Value.State = ServerState.Shutdown;
@@ -439,6 +444,7 @@ public partial class PlcServer : StandardServer
 
                     Thread.Sleep(TimeSpan.FromSeconds(1));
                 }
+#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
         catch

--- a/src/PlcServer.cs
+++ b/src/PlcServer.cs
@@ -431,7 +431,6 @@ public partial class PlcServer : StandardServer
             if (currentSessions.Count > 0)
             {
                 // provide some time for the connected clients to detect the shutdown state.
-#pragma warning disable CS0618 // Type or member is obsolete
                 ServerInternal.Status.Value.ShutdownReason = new LocalizedText(string.Empty, "Application closed."); // Invariant.
                 ServerInternal.Status.Variable.ShutdownReason.Value = new LocalizedText(string.Empty, "Application closed."); // Invariant.
                 ServerInternal.Status.Value.State = ServerState.Shutdown;
@@ -446,7 +445,6 @@ public partial class PlcServer : StandardServer
 
                     Thread.Sleep(TimeSpan.FromSeconds(1));
                 }
-#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
         catch

--- a/src/PluginNodes/ComplexTypeBoilerPluginNode.cs
+++ b/src/PluginNodes/ComplexTypeBoilerPluginNode.cs
@@ -59,6 +59,12 @@ public class ComplexTypeBoilerPluginNode(TimeService timeService, ILogger logger
         // Convert to node that can be manipulated within the server.
         _node = new Boiler1State(null);
         _node.Create(_plcNodeManager.SystemContext, passiveBoiler1Node);
+        _node.BoilerStatus.Value = new BoilerDataType {
+            Pressure = 99_000,
+            Temperature = new BoilerTemperatureType { Bottom = 100, Top = 95 },
+            HeaterState = BoilerHeaterStateType.On,
+        };
+        _node.BoilerStatus.ClearChangeMasks(_plcNodeManager.SystemContext, includeChildren: true);
 
         // Put Boiler #2 into Boilers folder.
         // TODO: Find a better solution to avoid this dependency between boilers.

--- a/tests/BoilerTests.cs
+++ b/tests/BoilerTests.cs
@@ -134,12 +134,11 @@ public class BoilerTests : SimulatorTestsBase
         var nodeId = NodeId.Create(BoilerModel1.Variables.Boiler1_BoilerStatus, OpcPlc.Namespaces.OpcPlcBoiler, Session.NamespaceUris);
         var value = Session.ReadValue(nodeId).Value;
 
+        // change dynamic in-memory created Boiler type to expected BoilerDataType by serializing and deserializing it.
+        var inmemoryBoilerDataType = (value as ExtensionObject).Body;
+        var json = JsonSerializer.Serialize(inmemoryBoilerDataType);
 
-        var x = (value as ExtensionObject).Body;
-        var json = JsonSerializer.Serialize(x);
-
-        var bt = JsonSerializer.Deserialize<BoilerDataType>(json);
-        return bt;
-        //return value.Should().BeOfType<ExtensionObject>().Which.Body.Should().BeOfType<BoilerDataType>().Subject;
+        var boilerDataTypeFromGeneratedSourceCode = JsonSerializer.Deserialize<BoilerDataType>(json);
+        return boilerDataTypeFromGeneratedSourceCode;
     }
 }

--- a/tests/DeterministicAlarmsTests.cs
+++ b/tests/DeterministicAlarmsTests.cs
@@ -26,7 +26,7 @@ public class DeterministicAlarmsTests : SubscriptionTestsBase
     [SetUp]
     public void CreateMonitoredItem()
     {
-        SetUpMonitoredItem(Objects.Server, NodeClass.Object, Attributes.EventNotifier);
+        SetUpMonitoredItem(AlarmNodeId("VendingMachines"), NodeClass.Object, Attributes.EventNotifier);
 
         AddMonitoredItem();
     }

--- a/tests/DeterministicAlarmsTests2.cs
+++ b/tests/DeterministicAlarmsTests2.cs
@@ -26,7 +26,7 @@ public class DeterministicAlarmsTests2 : SubscriptionTestsBase
     [SetUp]
     public void CreateMonitoredItem()
     {
-        SetUpMonitoredItem(Objects.Server, NodeClass.Object, Attributes.EventNotifier);
+        SetUpMonitoredItem(AlarmNodeId("VendingMachines"), NodeClass.Object, Attributes.EventNotifier);
 
         AddMonitoredItem();
     }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve, or functionality does it add? -->
When used via NuGet package in-memory, the server needs to use its own encodable factory. Otherwise, the client will not load the type definitions for decoding correctly. There is currently no public API to set the encodable factory and it is not possible to provide own implementation, because other classes require the `StandardServer` or `ServerInternalData` as objects, so we need to use reflection to set it. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->