### PR TITLE
Enforce that initial `EventId`s are deterministic

### DIFF
--- a/src/AlarmCondition/AlarmConditionNodeManager.cs
+++ b/src/AlarmCondition/AlarmConditionNodeManager.cs
@@ -29,9 +29,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection.Emit;
 using System.Threading;
 using Opc.Ua;
 using Opc.Ua.Server;
+using Opc.Ua.Test;
 
 namespace AlarmCondition
 {
@@ -271,7 +273,8 @@ namespace AlarmCondition
                     if (!m_sources.TryGetValue(sourcePath, out SourceState source))
                     {
                         NodeId sourceId = ModelUtils.ConstructIdForSource(sourcePath, NamespaceIndex);
-                        m_sources[sourcePath] = source = new SourceState(this, sourceId, sourcePath);
+                        ResetRandomGenerator(ii);
+                        m_sources[sourcePath] = source = new SourceState(this, sourceId, sourcePath, m_generator);
                     }
 
                     // HasEventSource and HasNotifier control the propagation of event notifications so
@@ -456,6 +459,14 @@ namespace AlarmCondition
                 cache?.Add(handle.NodeId, target);
             }
         }
+
+        private void ResetRandomGenerator(int seed, int boundaryValueFrequency = 0)
+        {
+            m_randomSource = new RandomSource(seed);
+            m_generator = new DataGenerator(m_randomSource);
+            m_generator.BoundaryValueFrequency = boundaryValueFrequency;
+        }
+
         #endregion
 
         #region Private Fields
@@ -463,6 +474,8 @@ namespace AlarmCondition
         private readonly Dictionary<string, AreaState> m_areas;
         private readonly Dictionary<string, SourceState> m_sources;
         private Timer m_simulationTimer;
+        private RandomSource m_randomSource;
+        private DataGenerator m_generator;
         #endregion
     }
 }

--- a/src/AlarmCondition/Model/SourceState.cs
+++ b/src/AlarmCondition/Model/SourceState.cs
@@ -263,7 +263,7 @@ namespace AlarmCondition
 
         private byte[] GetNextGuidAsByteArray()
         {
-            // Unpack the object to Uuid and then explicitly cast to Guid to access the byte[]
+            // unpack the object to Uuid and then explicit cast to Guid to access the byte[]
             // using RandomGenerator with known known seed to get reproducible results
             return ((Guid)((Uuid)m_generator.GetRandom(
                 NodeId.Parse($"i={(int)BuiltInType.Guid}"),

--- a/src/AlarmCondition/Model/SourceState.cs
+++ b/src/AlarmCondition/Model/SourceState.cs
@@ -263,7 +263,7 @@ namespace AlarmCondition
 
         private byte[] GetNextGuidAsByteArray()
         {
-            // unpack the object to Uuid and then explicit cast to Guid to access the byte[]
+            // Unpack the object to Uuid and then explicitly cast to Guid to access the byte[]
             // using RandomGenerator with known known seed to get reproducible results
             return ((Guid)((Uuid)m_generator.GetRandom(
                 NodeId.Parse($"i={(int)BuiltInType.Guid}"),

--- a/src/AlarmCondition/Model/SourceState.cs
+++ b/src/AlarmCondition/Model/SourceState.cs
@@ -27,9 +27,12 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using Microsoft.AspNetCore.Hosting.Server;
 using Opc.Ua;
+using Opc.Ua.Test;
 using System;
 using System.Collections.Generic;
+using System.Reflection.Emit;
 
 namespace AlarmCondition
 {
@@ -45,7 +48,8 @@ namespace AlarmCondition
         public SourceState(
             AlarmConditionServerNodeManager nodeManager,
             NodeId nodeId,
-            string sourcePath)
+            string sourcePath,
+            DataGenerator generator)
         :
             base(null)
         {
@@ -68,6 +72,7 @@ namespace AlarmCondition
             EventNotifier = EventNotifiers.None;
 
             // create a dialog.
+            m_generator = generator;
             m_dialog = CreateDialog("OnlineState");
 
             // create the table of conditions.
@@ -223,7 +228,7 @@ namespace AlarmCondition
             AddChild(node);
 
             // initialize event information.
-            node.EventId.Value = Guid.NewGuid().ToByteArray();
+            node.EventId.Value = GetNextGuidAsByteArray();
             node.EventType.Value = node.TypeDefinitionId;
             node.SourceNode.Value = NodeId;
             node.SourceName.Value = SymbolicName;
@@ -254,6 +259,16 @@ namespace AlarmCondition
 
             // return the new node.
             return node;
+        }
+
+        private byte[] GetNextGuidAsByteArray()
+        {
+            // unpack the object to Uuid and then explicit cast to Guid to access the byte[]
+            // using RandomGenerator with known known seed to get reproducible results
+            return ((Guid)((Uuid)m_generator.GetRandom(
+                NodeId.Parse($"i={(int)BuiltInType.Guid}"),
+                ValueRanks.Scalar, new uint[] { 1 },
+                m_nodeManager.Server.TypeTree))).ToByteArray();
         }
 
         /// <summary>
@@ -411,7 +426,7 @@ namespace AlarmCondition
             }
 
             // update the basic event information (include generating a unique id for the event).
-            node.EventId.Value = Guid.NewGuid().ToByteArray();
+            node.EventId.Value = GetNextGuidAsByteArray();
             node.Time.Value = DateTime.UtcNow;
             node.ReceiveTime.Value = node.Time.Value;
 
@@ -727,6 +742,7 @@ namespace AlarmCondition
         private readonly Dictionary<string, AlarmConditionState> m_events;
         private readonly Dictionary<NodeId, AlarmConditionState> m_branches;
         private readonly DialogConditionState m_dialog;
+        private DataGenerator m_generator;
         #endregion
     }
 }

--- a/src/AlarmCondition/Model/SourceState.cs
+++ b/src/AlarmCondition/Model/SourceState.cs
@@ -263,8 +263,8 @@ namespace AlarmCondition
 
         private byte[] GetNextGuidAsByteArray()
         {
-            // unpack the object to Uuid and then explicit cast to Guid to access the byte[]
-            // using RandomGenerator with known known seed to get reproducible results
+            // Unpack the object to Uuid and then explicitly cast to Guid to access the byte[]
+            // using a random generator with a known seed to get reproducible results.
             return ((Guid)((Uuid)m_generator.GetRandom(
                 NodeId.Parse($"i={(int)BuiltInType.Guid}"),
                 ValueRanks.Scalar, new uint[] { 1 },


### PR DESCRIPTION
## Purpose
`EventId`s are currently generate for each OPC PLC restart and each event, which makes testing against it, much harder. Thios change follows the pattern of the ReferenceNodeManager and generate deterministic IDs.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe:
```

## How to Test
```
git clone this repository
start the OPC PLC with `--autoaccept --alm`
```

* navigate to

![image](https://github.com/user-attachments/assets/cf210d51-2a3d-4520-97e7-722a097a3859)


## What to Check
Verify that the following are valid
* After multiple restarts the initial EventId of the Node is the same

## Other Information
<!-- Add any other helpful information that may be needed here. -->