### PR TITLE
Use code gen logging

### DIFF
--- a/src/Helpers/MetricsHelper.cs
+++ b/src/Helpers/MetricsHelper.cs
@@ -175,7 +175,7 @@ public static class MetricsHelper
             }
             else
             {
-                logger.LogDebug("Unknown notification type: {notificationType}", x.Body.GetType().Name);
+                logger.LogDebug("Unknown notification type: {NotificationType}", x.Body.GetType().Name);
             }
         });
 

--- a/src/Helpers/MetricsHelper.cs
+++ b/src/Helpers/MetricsHelper.cs
@@ -1,5 +1,7 @@
 namespace OpcPlc;
 
+using Microsoft.Extensions.Logging;
+using Opc.Ua;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
@@ -151,18 +153,37 @@ public static class MetricsHelper
     /// <summary>
     /// Add a published count.
     /// </summary>
-    public static void AddPublishedCount(string sessionId, string subscriptionId, int dataPoints, int events)
+    public static void AddPublishedCount(string sessionId, string subscriptionId, NotificationMessage notificationMessage, ILogger logger)
     {
         if (!IsEnabled)
         {
             return;
         }
 
-        if (dataPoints > 0)
+        int events = 0;
+        int dataChanges = 0;
+        int diagnostics = 0;
+        notificationMessage.NotificationData.ForEach(x => {
+            if (x.Body is DataChangeNotification changeNotification)
+            {
+                dataChanges += changeNotification.MonitoredItems.Count;
+                diagnostics += changeNotification.DiagnosticInfos.Count;
+            }
+            else if (x.Body is EventNotificationList eventNotification)
+            {
+                events += eventNotification.Events.Count;
+            }
+            else
+            {
+                logger.LogDebug("Unknown notification type: {notificationType}", x.Body.GetType().Name);
+            }
+        });
+
+        if (dataChanges > 0)
         {
             var dataPointsDimensions = MergeWithBaseDimensions(
                         new KeyValuePair<string, object>("type", "data_point"));
-            _publishedCountWithType.Add(dataPoints, dataPointsDimensions);
+            _publishedCountWithType.Add(dataChanges, dataPointsDimensions);
         }
 
         if (events > 0)

--- a/src/PlcServer.cs
+++ b/src/PlcServer.cs
@@ -224,7 +224,7 @@ public partial class PlcServer : StandardServer
 
             LogErrorWithStatusCode(
                 nameof(Publish),
-                StatusCodes.BadNoSubscription.ToString(),
+                nameof(StatusCodes.BadNoSubscription),
                 ex);
 
             return new ResponseHeader { ServiceResult = StatusCodes.BadNoSubscription };
@@ -235,7 +235,7 @@ public partial class PlcServer : StandardServer
 
             LogErrorWithStatusCode(
                 nameof(Publish),
-                StatusCodes.BadSessionIdInvalid.ToString(),
+                nameof(StatusCodes.BadSessionIdInvalid),
                 ex);
 
             return new ResponseHeader { ServiceResult = StatusCodes.BadSessionIdInvalid };
@@ -246,7 +246,7 @@ public partial class PlcServer : StandardServer
 
             LogErrorWithStatusCode(
                 nameof(Publish),
-                StatusCodes.BadSecureChannelIdInvalid.ToString(),
+                nameof(StatusCodes.BadSecureChannelIdInvalid),
                 ex);
 
             return new ResponseHeader { ServiceResult = StatusCodes.BadSecureChannelIdInvalid };

--- a/src/PlcServer.cs
+++ b/src/PlcServer.cs
@@ -248,24 +248,7 @@ public partial class PlcServer : StandardServer
 
             var responseHeader = base.Publish(requestHeader, subscriptionAcknowledgements, out subscriptionId, out availableSequenceNumbers, out moreNotifications, out notificationMessage, out results, out diagnosticInfos);
 
-            int events = 0;
-            int dataChanges = 0;
-            int diagnostics = 0;
-            notificationMessage.NotificationData.ForEach(x => {
-                if (x.Body is DataChangeNotification changeNotification)
-                {
-                    dataChanges += changeNotification.MonitoredItems.Count;
-                    diagnostics += changeNotification.DiagnosticInfos.Count;
-                }
-                else if (x.Body is EventNotificationList eventNotification)
-                {
-                    events += eventNotification.Events.Count;
-                }
-                else
-                {
-                    _logger.LogDebug("Unknown notification type: {notificationType}", x.Body.GetType().Name);
-                }
-            });
+            MetricsHelper.AddPublishedCount(context.SessionId.ToString(), subscriptionId.ToString(), notificationMessage, _logger);
 
             MetricsHelper.AddPublishedCount(context.SessionId.ToString(), subscriptionId.ToString(), dataChanges, events);
 

--- a/src/PlcServer.cs
+++ b/src/PlcServer.cs
@@ -552,7 +552,7 @@ public partial class PlcServer : StandardServer
     partial void LogError(string function, Exception exception);
 
     [LoggerMessage(
-        Level = LogLevel.Error,
+        Level = LogLevel.Debug,
         Message = "{Function} error: {StatusCode}")]
     partial void LogErrorWithStatusCode(string function, string statusCode, Exception exception);
 

--- a/tests/MetricsTests.cs
+++ b/tests/MetricsTests.cs
@@ -2,6 +2,7 @@ namespace OpcPlc.Tests;
 
 using FluentAssertions;
 using NUnit.Framework;
+using Opc.Ua;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
@@ -76,16 +77,6 @@ internal class MetricsTests
     {
         MetricsHelper.AddMonitoredItemCount(1);
         _metrics.TryGetValue("opc_plc_monitored_item_count", out var counter).Should().BeTrue();
-        counter.Should().Be(1);
-    }
-
-    [Test]
-    public void TestAddPublishedCount()
-    {
-        var sessionId = Guid.NewGuid().ToString();
-        var subscriptionId = Guid.NewGuid().ToString();
-        MetricsHelper.AddPublishedCount(sessionId, subscriptionId, 1, 0);
-        _metrics.TryGetValue("opc_plc_published_count_with_type", out var counter).Should().BeTrue();
         counter.Should().Be(1);
     }
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.12.20",
+  "version": "2.12.21",
   "versionHeightOffset": -1,
   "publicReleaseRefSpec": [
     "^refs/heads/main$",


### PR DESCRIPTION
* Use code gen logging
* Move metric calculation to helper to avoid execution when disabled
* Disable publish metrics when connected to more than 40 sessions or monitoring more than 500 items for better perf