### PR TITLE
Use single array as content for all VeryFastByteString nodes to save memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ More information about this feature can be found [here](deterministic-alarms.md)
 - Nodes with 1 kB (ByteString) values: `--vf1k`. The first byte cycles from 0 to 255 in a configurable rate in ms: `--vf1kr`. The values are deterministic but scrambled to ensure that they are not efficiently compressed.
 - Load binary *.PredefinedNodes.uanodes file(s) compiled from an XML NodeSet: `--unf=<PredefinedNodes_uanodes>`
 - Load *.NodeSet2.xml file(s): `--ns2=<NodeSet2_xml>`
+- Node that shows working set memory consumption in MB: Root/Objects/OpcPlc/Telemetry/Special/WorkingSetMB
 
 ## OPC UA Methods
 | Name                 | Description                                    | Prerequisite                                   |

--- a/src/AlarmCondition/AlarmConditionNodeManager.cs
+++ b/src/AlarmCondition/AlarmConditionNodeManager.cs
@@ -29,7 +29,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection.Emit;
 using System.Threading;
 using Opc.Ua;
 using Opc.Ua.Server;

--- a/src/PlcNodeManager.cs
+++ b/src/PlcNodeManager.cs
@@ -33,13 +33,11 @@ public class PlcNodeManager : CustomNodeManager2
     /// </summary>
     public override NodeId New(ISystemContext context, NodeState node)
     {
-        if (node is BaseInstanceState instance && instance.Parent != null &&
-            instance.Parent.NodeId.Identifier is string id)
-        {
-            return new NodeId(id + "_" + instance.SymbolicName, instance.Parent.NodeId.NamespaceIndex);
-        }
-
-        return node.NodeId;
+        return node is BaseInstanceState instance &&
+               instance.Parent != null &&
+               instance.Parent.NodeId.Identifier is string id
+                  ? new NodeId(id + "_" + instance.SymbolicName, instance.Parent.NodeId.NamespaceIndex)
+                  : node.NodeId;
     }
 
     /// <summary>

--- a/src/PluginNodes/VeryFast1KBPluginNodes.cs
+++ b/src/PluginNodes/VeryFast1KBPluginNodes.cs
@@ -59,7 +59,7 @@ public class VeryFast1KBPluginNodes(TimeService timeService, ILogger logger) : P
         // Only use the fast timers when we need to go really fast,
         // since they consume more resources and create an own thread.
         _nodeGenerator = NodeRate >= 50 || !Stopwatch.IsHighResolution
-            ? _timeService.NewTimer((s, e) => UpdateNodes(), NodeRate)
+            ? _timeService.NewTimer((s, e) => UpdateNodes(), intervalInMilliseconds: NodeRate)
             : _timeService.NewFastTimer((s, e) => UpdateNodes(), intervalInMilliseconds: NodeRate);
     }
 

--- a/src/PluginNodes/WorkingSetPluginNode.cs
+++ b/src/PluginNodes/WorkingSetPluginNode.cs
@@ -1,0 +1,68 @@
+namespace OpcPlc.PluginNodes;
+
+using Microsoft.Extensions.Logging;
+using Opc.Ua;
+using OpcPlc.Helpers;
+using OpcPlc.PluginNodes.Models;
+using System.Diagnostics;
+
+/// <summary>
+/// Node that shows current working set memory consumption in MB.
+/// </summary>
+public class WorkingSetPluginNode(TimeService timeService, ILogger logger) : PluginNodeBase(timeService, logger), IPluginNodes
+{
+    private PlcNodeManager _plcNodeManager;
+    private SimulatedVariableNode<uint> _node;
+
+    public void AddOptions(Mono.Options.OptionSet optionSet)
+    {
+        // Enabled by default.
+    }
+
+    public void AddToAddressSpace(FolderState telemetryFolder, FolderState methodsFolder, PlcNodeManager plcNodeManager)
+    {
+        _plcNodeManager = plcNodeManager;
+
+        FolderState folder = _plcNodeManager.CreateFolder(
+            telemetryFolder,
+            path: "Special",
+            name: "Special",
+            NamespaceType.OpcPlcApplications);
+
+        AddNodes(folder);
+    }
+
+    public void StartSimulation()
+    {
+        _node.Start(value => GetWorkingSetMB(), periodMs: 1000);
+    }
+
+    public void StopSimulation()
+    {
+        _node.Stop();
+    }
+
+    private void AddNodes(FolderState folder)
+    {
+        BaseDataVariableState variable = _plcNodeManager.CreateBaseVariable(
+            folder,
+            path: "WorkingSetMB",
+            name: "WorkingSetMB",
+            new NodeId((uint)BuiltInType.UInt32),
+            ValueRanks.Scalar,
+            AccessLevels.CurrentReadOrWrite,
+            "Working set memory consumption in MB",
+            NamespaceType.OpcPlcApplications,
+            defaultValue: GetWorkingSetMB());
+
+        _node = _plcNodeManager.CreateVariableNode<uint>(variable);
+
+        // Add to node list for creation of pn.json.
+        Nodes =
+        [
+            PluginNodesHelper.GetNodeWithIntervals(variable.NodeId, _plcNodeManager),
+        ];
+    }
+
+    private uint GetWorkingSetMB() => (uint)(Process.GetCurrentProcess().WorkingSet64 / 1024 / 1024);
+}

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.12.22",
+  "version": "2.12.23",
   "versionHeightOffset": -1,
   "publicReleaseRefSpec": [
     "^refs/heads/main$",


### PR DESCRIPTION
* Use single array as content for all VeryFastByteString nodes to save memory
* Add total sessions/subscriptions to periodic log
* Use loglevel check for more efficient logging in hot paths
* Add node with WorkingSetMB

![image](https://github.com/user-attachments/assets/3c6ab8ee-104f-46cc-a4b5-0d20bee7aef1)