### PR TITLE
Snap with dotnet plugin

### DIFF
--- a/scripts/run
+++ b/scripts/run
@@ -1,3 +1,8 @@
 #!/bin/sh -e
 
-$SNAP/opcplc --pn=50000 --sn=10 --sr=10 --st=uint --fn=10 --fr=1 --ft=uint --gn=10 --appcertstorepath="$SNAP_USER_DATA/pki/own" --trustedcertstorepath="$SNAP_USER_DATA/pki/trusted" --rejectedcertstorepath="$SNAP_USER_DATA/pki/rejected" --issuercertstorepath="$SNAP_USER_DATA/pki/issuer" --logfile="$SNAP_USER_DATA/hostname-port-plc.log" --uanodesfile="$SNAP/CompanionSpecs/DI/Opc.Ua.DI.PredefinedNodes.uanodes"
+"$SNAP"/opcplc --pn=50000 --sn=10 --sr=10 --st=uint --fn=10 --fr=1 --ft=uint --gn=10 \
+    --appcertstorepath="$SNAP_USER_DATA/pki/own" \
+    --trustedcertstorepath="$SNAP_USER_DATA/pki/trusted" \
+    --rejectedcertstorepath="$SNAP_USER_DATA/pki/rejected" \
+    --issuercertstorepath="$SNAP_USER_DATA/pki/issuer" \
+    --logfile="$SNAP_USER_DATA/hostname-port-plc.log"

--- a/scripts/run
+++ b/scripts/run
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+$SNAP/opcplc --pn=50000 --sn=10 --sr=10 --st=uint --fn=10 --fr=1 --ft=uint --gn=10 --appcertstorepath="$SNAP_USER_DATA/pki/own" --trustedcertstorepath="$SNAP_USER_DATA/pki/trusted" --rejectedcertstorepath="$SNAP_USER_DATA/pki/rejected" --issuercertstorepath="$SNAP_USER_DATA/pki/issuer" --logfile="$SNAP_USER_DATA/hostname-port-plc.log" --uanodesfile="$SNAP/CompanionSpecs/DI/Opc.Ua.DI.PredefinedNodes.uanodes"

--- a/scripts/run
+++ b/scripts/run
@@ -1,8 +1,16 @@
 #!/bin/sh -e
 
-"$SNAP"/opcplc --pn=50000 --sn=10 --sr=10 --st=uint --fn=10 --fr=1 --ft=uint --gn=10 \
-    --appcertstorepath="$SNAP_USER_DATA/pki/own" \
-    --trustedcertstorepath="$SNAP_USER_DATA/pki/trusted" \
-    --rejectedcertstorepath="$SNAP_USER_DATA/pki/rejected" \
-    --issuercertstorepath="$SNAP_USER_DATA/pki/issuer" \
-    --logfile="$SNAP_USER_DATA/hostname-port-plc.log"
+trustedcertbase64="$(snapctl get trustedcertbase64)"
+
+cmd="\"$SNAP\"/opcplc --pn=50000 --sn=10 --sr=10 --st=uint --fn=10 --fr=1 --ft=uint --gn=10 \
+    --appcertstorepath=\"$SNAP_USER_DATA/pki/own\" \
+    --trustedcertstorepath=\"$SNAP_USER_DATA/pki/trusted\" \
+    --rejectedcertstorepath=\"$SNAP_USER_DATA/pki/rejected\" \
+    --issuercertstorepath=\"$SNAP_USER_DATA/pki/issuer\" \
+    --logfile=\"$SNAP_USER_DATA/hostname-port-plc.log\""
+
+if [ -n "$trustedcertbase64" ]; then
+  cmd="$cmd --addtrustedcertfile=\"$SNAP_DATA/config/pki/trusted/certs/cert_1.crt\""
+fi
+
+eval "$cmd"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,15 @@
+#!/bin/sh -e
+
+# Supported keys:
+# - trustedcertbase64 (string)
+#   Certificate in base64 string format to be trusted by the server.
+
+handle_trustedcertbase64()
+{
+  trustedcertbase64="$(snapctl get trustedcertbase64)"
+  if [ -n "$trustedcertbase64" ]; then
+    echo "$trustedcertbase64" > "$SNAP_DATA/config/pki/trusted/certs/cert_1.crt"
+  fi
+}
+
+handle_trustedcertbase64

--- a/snap/hooks/default-configure
+++ b/snap/hooks/default-configure
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+mkdir -p "$SNAP_DATA/config/pki/trusted/certs"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,6 +22,11 @@ parts:
     source: scripts/
     organize:
       '*' : scripts/
+  appsettings:
+    plugin: dump
+    source: src/
+    prime:
+      - appsettings.json
 
 apps:
   opc-plc:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,31 @@
+name: iot-edge-opc-plc
+base: core22
+version: '0.1'
+summary: Sample OPC UA server
+description: |
+  Sample OPC UA server with nodes that generate random
+  and increasing data, anomalies and much more.
+
+grade: stable
+confinement: strict # use 'strict' once you have the right plugs and slots
+
+parts:
+  opc-plc:
+    plugin: dotnet
+    dotnet-build-configuration: Release
+    dotnet-self-contained-runtime-identifier: linux-x64
+    source: .
+    build-packages:
+      - dotnet-sdk-8.0
+  scripts:
+    plugin: dump
+    source: scripts/
+    organize:
+      '*' : scripts/
+
+apps:
+  opc-plc:
+    command: scripts/run
+    plugs:
+      - network
+      - network-bind

--- a/src/CompanionSpecs/DI/DiNodeManager.cs
+++ b/src/CompanionSpecs/DI/DiNodeManager.cs
@@ -2,6 +2,8 @@
 
 using Opc.Ua;
 using Opc.Ua.Server;
+using System;
+using System.IO;
 using System.Reflection;
 
 /// <summary>
@@ -29,9 +31,16 @@ public sealed class DiNodeManager : CustomNodeManager2
     /// </summary>
     protected override NodeStateCollection LoadPredefinedNodes(ISystemContext context)
     {
+        var uanodesPath = "CompanionSpecs/DI/Opc.Ua.DI.PredefinedNodes.uanodes";
+        var snapLocation = Environment.GetEnvironmentVariable("SNAP");
+        if (!string.IsNullOrWhiteSpace(snapLocation))
+        {
+            // Aplication running as a snap
+            uanodesPath = Path.Join(snapLocation, uanodesPath);
+        }
         var predefinedNodes = new NodeStateCollection();
         predefinedNodes.LoadFromBinaryResource(context,
-            "CompanionSpecs/DI/Opc.Ua.DI.PredefinedNodes.uanodes", // CopyToOutputDirectory -> PreserveNewest.
+            uanodesPath, // CopyToOutputDirectory -> PreserveNewest.
             typeof(DiNodeManager).GetTypeInfo().Assembly,
             updateTables: true);
 

--- a/src/OpcPlcServer.cs
+++ b/src/OpcPlcServer.cs
@@ -374,9 +374,17 @@ public class OpcPlcServer
     /// </summary>
     public IHost CreateHostBuilder(string[] args)
     {
+        var contentRoot = Directory.GetCurrentDirectory();
+        var snapLocation = Environment.GetEnvironmentVariable("SNAP");
+        if (!string.IsNullOrWhiteSpace(snapLocation))
+        {
+            // The application is running as a snap
+            contentRoot = snapLocation;
+        }
+
         var host = Host.CreateDefaultBuilder(args)
             .ConfigureWebHostDefaults(webBuilder => {
-                webBuilder.UseContentRoot(Directory.GetCurrentDirectory()); // Avoid System.InvalidOperationException.
+                webBuilder.UseContentRoot(contentRoot); // Avoid System.InvalidOperationException.
                 webBuilder.UseUrls($"http://*:{Config.WebServerPort}");
                 webBuilder.UseStartup<Startup>();
             }).Build();

--- a/src/PluginNodes/Boiler2PluginNodes.cs
+++ b/src/PluginNodes/Boiler2PluginNodes.cs
@@ -7,6 +7,7 @@ using OpcPlc.Helpers;
 using OpcPlc.PluginNodes.Models;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -154,10 +155,18 @@ public class Boiler2PluginNodes(TimeService timeService, ILogger logger) : Plugi
     /// </summary>
     private NodeStateCollection LoadPredefinedNodes(ISystemContext context)
     {
+        var uanodesPath = "Boilers/Boiler2/BoilerModel2.PredefinedNodes.uanodes";
+        var snapLocation = Environment.GetEnvironmentVariable("SNAP");
+        if (!string.IsNullOrWhiteSpace(snapLocation))
+        {
+            // Aplication running as a snap
+            uanodesPath = Path.Join(snapLocation, uanodesPath);
+        }
+
         var predefinedNodes = new NodeStateCollection();
 
         predefinedNodes.LoadFromBinaryResource(context,
-            "Boilers/Boiler2/BoilerModel2.PredefinedNodes.uanodes", // CopyToOutputDirectory -> PreserveNewest.
+            uanodesPath, // CopyToOutputDirectory -> PreserveNewest.
             typeof(PlcNodeManager).GetTypeInfo().Assembly,
             updateTables: true);
 

--- a/src/PluginNodes/ComplexTypeBoilerPluginNode.cs
+++ b/src/PluginNodes/ComplexTypeBoilerPluginNode.cs
@@ -7,6 +7,7 @@ using OpcPlc.Helpers;
 using OpcPlc.PluginNodes.Models;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using System.Timers;
 
@@ -90,10 +91,18 @@ public class ComplexTypeBoilerPluginNode(TimeService timeService, ILogger logger
     /// </summary>
     private NodeStateCollection LoadPredefinedNodes(ISystemContext context)
     {
+        var uanodesPath = "Boilers/Boiler1/BoilerModel1.PredefinedNodes.uanodes";
+        var snapLocation = Environment.GetEnvironmentVariable("SNAP");
+        if (!string.IsNullOrWhiteSpace(snapLocation))
+        {
+            // Aplication running as a snap
+            uanodesPath = Path.Join(snapLocation, uanodesPath);
+        }
+
         var predefinedNodes = new NodeStateCollection();
 
         predefinedNodes.LoadFromBinaryResource(context,
-            "Boilers/Boiler1/BoilerModel1.PredefinedNodes.uanodes", // CopyToOutputDirectory -> PreserveNewest.
+            uanodesPath, // CopyToOutputDirectory -> PreserveNewest.
             typeof(PlcNodeManager).GetTypeInfo().Assembly,
             updateTables: true);
 

--- a/src/SimpleEvent/SimpleEventsNodeManager.cs
+++ b/src/SimpleEvent/SimpleEventsNodeManager.cs
@@ -34,6 +34,7 @@ using Opc.Ua.Server;
 using OpcPlc.SimpleEvent;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using System.Threading;
 
@@ -88,9 +89,17 @@ public sealed class SimpleEventsNodeManager : CustomNodeManager2
     /// </summary>
     protected override NodeStateCollection LoadPredefinedNodes(ISystemContext context)
     {
+        var uanodesPath = "SimpleEvent/SimpleEvents.PredefinedNodes.uanodes";
+        var snapLocation = Environment.GetEnvironmentVariable("SNAP");
+        if (!string.IsNullOrWhiteSpace(snapLocation))
+        {
+            // Aplication running as a snap
+            uanodesPath = Path.Join(snapLocation, uanodesPath);
+        }
+
         var predefinedNodes = new NodeStateCollection();
         predefinedNodes.LoadFromBinaryResource(context,
-            "SimpleEvent/SimpleEvents.PredefinedNodes.uanodes",
+            uanodesPath,
             typeof(SimpleEventsNodeManager).GetTypeInfo().Assembly,
             updateTables: true);
         return predefinedNodes;


### PR DESCRIPTION
Changes to be able to build and run the server as a snap.

This is a minimal snap containing:
- some hard-coded cli options on the run command
- one snap configuration exposed _trustedcertbase64_, for configuring a trusted certificate

This minimal snap version should be enough to run the [Azure IoT Operations Quickstart](https://learn.microsoft.com/en-us/azure/iot-operations/get-started-end-to-end-sample/quickstart-deploy) with a plc simulator that is outside of the Kubernetes cluster and able to securely communicate with the cluster.