### PR TITLE
chore: Add snap build architectures

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,11 @@ description: |
   and increasing data, anomalies and much more.
 
 grade: stable
-confinement: strict # use 'strict' once you have the right plugs and slots
+confinement: strict
+
+architectures:
+  - build-on: amd64
+  - build-on: arm64
 
 parts:
   opc-plc:


### PR DESCRIPTION
Add explicit build architectures on snapcraft.yaml (amd64, arm64). Otherwise Launchpad tries to build the snap for more (all) architectures and fails.