### PR TITLE
Using windows-2022 VM image for ACR Build stage.

### DIFF
--- a/tools/templates/acrbuild.yml
+++ b/tools/templates/acrbuild.yml
@@ -5,7 +5,7 @@ jobs:
 - job: imagesprep
   displayName: Prepare Image Jobs
   pool:
-    name: Hosted Windows 2019 with VS2019
+    vmImage: 'windows-2022'
   variables:
     skipComponentGovernanceDetection: true
   steps:
@@ -18,7 +18,7 @@ jobs:
 - job: imagesall
   displayName: Build Images for
   pool:
-    name: Hosted Windows 2019 with VS2019
+    vmImage: 'windows-2022'
   dependsOn: imagesprep
   strategy:
     matrix: $[ dependencies.imagesprep.outputs['acrmatrix.acrMatrix'] ]


### PR DESCRIPTION
## Purpose

Using `windows-2022` VM image for ACR Build stage instead of `windows-2019` which is being deprecated.

Warning from pipeline run: https://msazure.visualstudio.com/One/_build/results?buildId=135347278&view=results

<img width="1398" height="202" alt="image" src="https://github.com/user-attachments/assets/18a6c283-4287-4536-8ee7-b2a8d3961eb2" />
