### PR TITLE
Use a round-robin data generator for alarms and events

### DIFF
--- a/src/AlarmCondition/AlarmConditionNodeManager.cs
+++ b/src/AlarmCondition/AlarmConditionNodeManager.cs
@@ -461,8 +461,7 @@ namespace AlarmCondition
 
         private void ResetRandomGenerator(int seed, int boundaryValueFrequency = 0)
         {
-            m_randomSource = new RandomSource(seed);
-            m_generator = new DataGenerator(m_randomSource);
+            m_generator = new DataGenerator(new RandomSource(seed));
             m_generator.BoundaryValueFrequency = boundaryValueFrequency;
         }
 
@@ -473,7 +472,6 @@ namespace AlarmCondition
         private readonly Dictionary<string, AreaState> m_areas;
         private readonly Dictionary<string, SourceState> m_sources;
         private Timer m_simulationTimer;
-        private RandomSource m_randomSource;
         private DataGenerator m_generator;
         #endregion
     }

--- a/src/AlarmCondition/AlarmConditionNodeManager.cs
+++ b/src/AlarmCondition/AlarmConditionNodeManager.cs
@@ -33,6 +33,7 @@ using System.Threading;
 using Opc.Ua;
 using Opc.Ua.Server;
 using Opc.Ua.Test;
+using OpcPlc.AlarmCondition;
 
 namespace AlarmCondition
 {
@@ -461,7 +462,7 @@ namespace AlarmCondition
 
         private void ResetRandomGenerator(int seed, int boundaryValueFrequency = 0)
         {
-            m_generator = new DataGenerator(new RandomSource(seed));
+            m_generator = new DataGenerator(new RoundRobinSource(seed));
             m_generator.BoundaryValueFrequency = boundaryValueFrequency;
         }
 

--- a/src/AlarmCondition/RoundRobinSource.cs
+++ b/src/AlarmCondition/RoundRobinSource.cs
@@ -1,0 +1,29 @@
+namespace OpcPlc.AlarmCondition;
+
+using Opc.Ua.Test;
+
+/// <summary>
+/// Returns sequential numbers in a round-robin fashion.
+/// </summary>
+public class RoundRobinSource : IRandomSource
+{
+    int _seed;
+
+    /// <summary>
+    /// Initializes the source with a seed.
+    /// </summary>
+    public RoundRobinSource(int seed)
+    {
+        _seed = seed;
+    }
+
+    public void NextBytes(byte[] bytes, int offset, int count)
+    {
+        // Not used.
+    }
+
+    public int NextInt32(int max)
+    {
+        return _seed++ % max;
+    }
+}

--- a/src/PlcServer.cs
+++ b/src/PlcServer.cs
@@ -1,6 +1,6 @@
 namespace OpcPlc;
 
-using AlarmCondition;
+using global::AlarmCondition;
 using Microsoft.Extensions.Logging;
 using Opc.Ua;
 using Opc.Ua.Bindings;


### PR DESCRIPTION
* Use a round-robin data generator, instead of a random one, for deterministic behavior when raising alarms and events