### PR TITLE
MinimumCertificateKeySize and RejectSHA1SignedCertificates via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,11 @@ Options:
       --aa, --autoaccept     all certs are trusted when a connection is
                                established.
                                Default: False
+      --rsha1, --rejectsha1  reject SHA1 signed certificates.
+                               Default: False
+      --mks, --mincertkeysize=VALUE
+                             the minimum certificate key size allowed.
+                               Default: 2048
       --drurs, --dontrejectunknownrevocationstatus
                              Don't reject chain validation with CA certs with
                                unknown revocation status, e.g. when the CRL is

--- a/src/Configuration/CliOptions.cs
+++ b/src/Configuration/CliOptions.cs
@@ -92,6 +92,10 @@ public static class CliOptions
             },
             { "aa|autoaccept", $"all certs are trusted when a connection is established.\nDefault: {config.OpcUa.AutoAcceptCerts}", (s) => config.OpcUa.AutoAcceptCerts = s != null },
 
+            { "rsha1|rejectsha1", $"reject SHA1 signed certificates.\nDefault: {config.OpcUa.RejectSHA1SignedCertificates}", (s) => config.OpcUa.RejectSHA1SignedCertificates = s != null },
+
+            { "mks|mincertkeysize=", $"the minimum certificate key size allowed.\nDefault: {config.OpcUa.MinimumCertificateKeySize}", (ushort i) => config.OpcUa.MinimumCertificateKeySize = i },
+
             { "drurs|dontrejectunknownrevocationstatus", $"Don't reject chain validation with CA certs with unknown revocation status, e.g. when the CRL is not available or the OCSP provider is offline.\nDefault: {config.OpcUa.DontRejectUnknownRevocationStatus}", (s) => config.OpcUa.DontRejectUnknownRevocationStatus = s != null },
 
             { "ut|unsecuretransport", $"enables the unsecured transport.\nDefault: {config.OpcUa.EnableUnsecureTransport}", (s) => config.OpcUa.EnableUnsecureTransport = s != null },

--- a/src/Configuration/OpcApplicationConfigurationSecurity.cs
+++ b/src/Configuration/OpcApplicationConfigurationSecurity.cs
@@ -58,6 +58,16 @@ public partial class OpcApplicationConfiguration
     public string OpcUserIssuerCertStorePath { get; set; }
 
     /// <summary>
+    /// Reject SHA1 signed certificates.
+    /// </summary>
+    public bool RejectSHA1SignedCertificates { get; set; }
+
+    /// <summary>
+    /// Minimum certificate key size in bits.
+    /// </summary>
+    public ushort MinimumCertificateKeySize { get; set; } = 2048;
+
+    /// <summary>
     /// Accept certs of the clients automatically.
     /// </summary>
     public bool AutoAcceptCerts { get; set; }

--- a/src/Configuration/OpcUaAppConfigFactory.cs
+++ b/src/Configuration/OpcUaAppConfigFactory.cs
@@ -247,8 +247,8 @@ public partial class OpcUaAppConfigFactory(
         var options = securityBuilder.AddSecurityConfiguration(applicationCerts, _config.OpcUa.OpcOwnPKIRootDefault, rejectedRoot: null)
             .SetAutoAcceptUntrustedCertificates(_config.OpcUa.AutoAcceptCerts)
             .SetRejectUnknownRevocationStatus(!_config.OpcUa.DontRejectUnknownRevocationStatus)
-            .SetRejectSHA1SignedCertificates(false)
-            .SetMinimumCertificateKeySize(1024)
+            .SetRejectSHA1SignedCertificates(_config.OpcUa.RejectSHA1SignedCertificates)
+            .SetMinimumCertificateKeySize(_config.OpcUa.MinimumCertificateKeySize)
             .SetAddAppCertToTrustedStore(_config.OpcUa.TrustMyself);
 
         var securityConfiguration = _config.OpcUa.ApplicationConfiguration.SecurityConfiguration;

--- a/tests/Configuration/CliOptionsTests.cs
+++ b/tests/Configuration/CliOptionsTests.cs
@@ -115,4 +115,94 @@ public class CliOptionsTests
         config.OpcUa.OpcTrustedUserCertStorePath.Should().Be(trustedUserPath);
         config.OpcUa.OpcUserIssuerCertStorePath.Should().Be(userIssuerPath);
     }
+
+    [Test]
+    public void Parse_RejectSha1_DefaultIsFalse()
+    {
+        // Arrange
+        var config = new OpcPlcConfiguration();
+        var args = System.Array.Empty<string>();
+        var pluginNodes = ImmutableList<OpcPlc.PluginNodes.Models.IPluginNodes>.Empty;
+
+        // Act
+        _ = CliOptions.InitConfiguration(args, config, pluginNodes);
+
+        // Assert
+        config.OpcUa.RejectSHA1SignedCertificates.Should().BeFalse();
+    }
+
+    [Test]
+    public void Parse_RejectSha1Flag_SetsConfigToTrue()
+    {
+        // Arrange
+        var config = new OpcPlcConfiguration();
+        var args = new[] { "--rejectsha1" };
+        var pluginNodes = ImmutableList<OpcPlc.PluginNodes.Models.IPluginNodes>.Empty;
+
+        // Act
+        _ = CliOptions.InitConfiguration(args, config, pluginNodes);
+
+        // Assert
+        config.OpcUa.RejectSHA1SignedCertificates.Should().BeTrue();
+    }
+
+    [Test]
+    public void Parse_RejectSha1ShortFlag_SetsConfigToTrue()
+    {
+        // Arrange
+        var config = new OpcPlcConfiguration();
+        var args = new[] { "--rsha1" };
+        var pluginNodes = ImmutableList<OpcPlc.PluginNodes.Models.IPluginNodes>.Empty;
+
+        // Act
+        _ = CliOptions.InitConfiguration(args, config, pluginNodes);
+
+        // Assert
+        config.OpcUa.RejectSHA1SignedCertificates.Should().BeTrue();
+    }
+
+    [Test]
+    public void Parse_MinCertKeySize_DefaultIs2048()
+    {
+        // Arrange
+        var config = new OpcPlcConfiguration();
+        var args = System.Array.Empty<string>();
+        var pluginNodes = ImmutableList<OpcPlc.PluginNodes.Models.IPluginNodes>.Empty;
+
+        // Act
+        _ = CliOptions.InitConfiguration(args, config, pluginNodes);
+
+        // Assert
+        config.OpcUa.MinimumCertificateKeySize.Should().Be(2048);
+    }
+
+    [Test]
+    public void Parse_MinCertKeySize_SetsConfigValue()
+    {
+        // Arrange
+        var config = new OpcPlcConfiguration();
+        var args = new[] { "--mincertkeysize=4096" };
+        var pluginNodes = ImmutableList<OpcPlc.PluginNodes.Models.IPluginNodes>.Empty;
+
+        // Act
+        _ = CliOptions.InitConfiguration(args, config, pluginNodes);
+
+        // Assert
+        config.OpcUa.MinimumCertificateKeySize.Should().Be(4096);
+    }
+
+    [Test]
+    public void Parse_MinCertKeySizeShortOption_SetsConfigValue()
+    {
+        // Arrange
+        var config = new OpcPlcConfiguration();
+        var args = new[] { "--mks=1024" };
+        var pluginNodes = ImmutableList<OpcPlc.PluginNodes.Models.IPluginNodes>.Empty;
+
+        // Act
+        _ = CliOptions.InitConfiguration(args, config, pluginNodes);
+
+        // Assert
+        config.OpcUa.MinimumCertificateKeySize.Should().Be(1024);
+    }
 }

--- a/tests/Configuration/OpcUaAppConfigFactoryTests.cs
+++ b/tests/Configuration/OpcUaAppConfigFactoryTests.cs
@@ -328,4 +328,132 @@ public class OpcUaAppConfigFactoryTests
             try { Directory.Delete(root, recursive: true); } catch { };
         }
     }
+
+    [Test]
+    [TestCase((ushort)1024)]
+    [TestCase((ushort)2048)]
+    [TestCase((ushort)4096)]
+    public async Task ConfigureAsync_MinimumCertificateKeySize_AppliedToSecurityConfiguration(ushort keySize)
+    {
+        // Arrange
+        string root = Path.Combine(Path.GetTempPath(), "opcplc_test_pki_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var config = new OpcPlcConfiguration();
+            config.OpcUa.OpcOwnCertStoreType = FlatDirectoryCertificateStore.StoreTypeName;
+            config.OpcUa.OpcOwnCertStorePath = Path.Combine(root, "own");
+            config.OpcUa.OpcTrustedCertStorePath = Path.Combine(root, "trusted");
+            config.OpcUa.OpcRejectedCertStorePath = Path.Combine(root, "rejected");
+            config.OpcUa.OpcIssuerCertStorePath = Path.Combine(root, "issuer");
+            config.OpcUa.OpcTrustedUserCertStorePath = Path.Combine(root, "trusted-user");
+            config.OpcUa.OpcUserIssuerCertStorePath = Path.Combine(root, "issuer-user");
+            config.OpcUa.MinimumCertificateKeySize = keySize;
+
+            Directory.CreateDirectory(config.OpcUa.OpcOwnCertStorePath);
+
+            var loggerMock = new Mock<ILogger>();
+            var loggerFactoryMock = new Mock<ILoggerFactory>();
+            loggerFactoryMock.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(loggerMock.Object);
+            var telemetryContext = new OpcTelemetryContext(loggerFactoryMock.Object, "Opc.Ua", OpcTelemetryContext.ResolveOpcPlcVersion());
+
+            var factory = new OpcUaAppConfigFactory(config, loggerMock.Object, loggerFactoryMock.Object, telemetryContext);
+
+            // Act
+            var appConfig = await factory.ConfigureAsync().ConfigureAwait(false);
+
+            // Assert - security configuration should reflect the requested minimum key size
+            appConfig.SecurityConfiguration.MinimumCertificateKeySize.Should().Be(keySize);
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { };
+        }
+    }
+
+    [Test]
+    public async Task ConfigureAsync_MinimumCertificateKeySize_GeneratedCertificateMeetsMinimum()
+    {
+        // Arrange
+        string root = Path.Combine(Path.GetTempPath(), "opcplc_test_pki_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var config = new OpcPlcConfiguration();
+            config.OpcUa.OpcOwnCertStoreType = FlatDirectoryCertificateStore.StoreTypeName;
+            config.OpcUa.OpcOwnCertStorePath = Path.Combine(root, "own");
+            config.OpcUa.OpcTrustedCertStorePath = Path.Combine(root, "trusted");
+            config.OpcUa.OpcRejectedCertStorePath = Path.Combine(root, "rejected");
+            config.OpcUa.OpcIssuerCertStorePath = Path.Combine(root, "issuer");
+            config.OpcUa.OpcTrustedUserCertStorePath = Path.Combine(root, "trusted-user");
+            config.OpcUa.OpcUserIssuerCertStorePath = Path.Combine(root, "issuer-user");
+            config.OpcUa.MinimumCertificateKeySize = 2048;
+
+            Directory.CreateDirectory(config.OpcUa.OpcOwnCertStorePath);
+
+            var loggerMock = new Mock<ILogger>();
+            var loggerFactoryMock = new Mock<ILoggerFactory>();
+            loggerFactoryMock.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(loggerMock.Object);
+            var telemetryContext = new OpcTelemetryContext(loggerFactoryMock.Object, "Opc.Ua", OpcTelemetryContext.ResolveOpcPlcVersion());
+
+            var factory = new OpcUaAppConfigFactory(config, loggerMock.Object, loggerFactoryMock.Object, telemetryContext);
+
+            // Act
+            var appConfig = await factory.ConfigureAsync().ConfigureAwait(false);
+
+            // Assert - the generated application certificate key size should meet the minimum
+            var certificate = appConfig.SecurityConfiguration.ApplicationCertificate.Certificate;
+            certificate.Should().NotBeNull("a self-signed application certificate should have been created");
+
+            using var rsaKey = certificate.GetRSAPublicKey();
+            rsaKey.Should().NotBeNull();
+            rsaKey.KeySize.Should().BeGreaterThanOrEqualTo(config.OpcUa.MinimumCertificateKeySize,
+                "generated application certificate key size should meet or exceed the configured minimum");
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { };
+        }
+    }
+
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task ConfigureAsync_RejectSHA1SignedCertificates_AppliedToSecurityConfiguration(bool rejectSha1)
+    {
+        // Arrange
+        string root = Path.Combine(Path.GetTempPath(), "opcplc_test_pki_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var config = new OpcPlcConfiguration();
+            config.OpcUa.OpcOwnCertStoreType = FlatDirectoryCertificateStore.StoreTypeName;
+            config.OpcUa.OpcOwnCertStorePath = Path.Combine(root, "own");
+            config.OpcUa.OpcTrustedCertStorePath = Path.Combine(root, "trusted");
+            config.OpcUa.OpcRejectedCertStorePath = Path.Combine(root, "rejected");
+            config.OpcUa.OpcIssuerCertStorePath = Path.Combine(root, "issuer");
+            config.OpcUa.OpcTrustedUserCertStorePath = Path.Combine(root, "trusted-user");
+            config.OpcUa.OpcUserIssuerCertStorePath = Path.Combine(root, "issuer-user");
+            config.OpcUa.RejectSHA1SignedCertificates = rejectSha1;
+
+            Directory.CreateDirectory(config.OpcUa.OpcOwnCertStorePath);
+
+            var loggerMock = new Mock<ILogger>();
+            var loggerFactoryMock = new Mock<ILoggerFactory>();
+            loggerFactoryMock.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(loggerMock.Object);
+            var telemetryContext = new OpcTelemetryContext(loggerFactoryMock.Object, "Opc.Ua", OpcTelemetryContext.ResolveOpcPlcVersion());
+
+            var factory = new OpcUaAppConfigFactory(config, loggerMock.Object, loggerFactoryMock.Object, telemetryContext);
+
+            // Act
+            var appConfig = await factory.ConfigureAsync().ConfigureAwait(false);
+
+            // Assert
+            appConfig.SecurityConfiguration.RejectSHA1SignedCertificates.Should().Be(rejectSha1);
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { };
+        }
+    }
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.14.9",
+  "version": "2.14.10",
   "versionHeightOffset": -1,
   "publicReleaseRefSpec": [
     "^refs/heads/main$",


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Add two new CLI options to control OPC UA security certificate validation:

- --mks|--mincertkeysize=VALUE: Set the minimum accepted certificate key size in bits (default changed from 1024 to 2048)
- --rsha1|--rejectsha1: Enable rejection of SHA1 signed certificates (default: false)

Both values were previously hardcoded in OpcUaAppConfigFactory and are now backed by properties on OpcApplicationConfiguration, wired through CliOptions, and documented in README.md.

The main reason was a braking change in stack introduced by: https://github.com/OPCFoundation/UA-.NETStandard/pull/3513. this changes the behavior of the own certificate generation from 2024 to whatever is configured per  minimum accepted certificate key size

Tests added:
- CLI parsing tests for both options (defaults, long/short forms, custom values)
- Integration tests verifying SecurityConfiguration reflects configured values
- Integration test asserting the generated application certificate key size meets the configured minimum

the main issue was the fact that the default behavior of the stack changed in the latest update: 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->