### PR TITLE
Fix version in docker container

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -19,6 +19,12 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then ARCH=x64; else ARCH="$TARGETARCH"; fi \
 # Copy source code
 COPY src/ src/
 
+# Copy git metadata and version file so Nerdbank.GitVersioning can compute the
+# real version. Without these, the version falls back to 0.0.0.
+# Requires a full (non-shallow) git history in the build context.
+COPY .git/ .git/
+COPY version.json .
+
 # Publish
 WORKDIR /app/src
 RUN if [ "$TARGETARCH" = "amd64" ]; then ARCH=x64; else ARCH="$TARGETARCH"; fi \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -19,6 +19,12 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then ARCH=x64; else ARCH="$TARGETARCH"; fi \
 # Copy source code
 COPY src/ src/
 
+# Copy git metadata and version file so Nerdbank.GitVersioning can compute the
+# real version. Without these, the version falls back to 0.0.0.
+# Requires a full (non-shallow) git history in the build context.
+COPY .git/ .git/
+COPY version.json .
+
 # Publish
 WORKDIR /app/src
 RUN if [ "$TARGETARCH" = "amd64" ]; then ARCH=x64; else ARCH="$TARGETARCH"; fi \

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.14.21",
+  "version": "2.14.22",
   "versionHeightOffset": -1,
   "publicReleaseRefSpec": [
     "^refs/heads/main$",


### PR DESCRIPTION
Currently the OpcPlc version shows up as 0.0.0 inside of a container because nerdbank needs git history to determine the version.