### PR TITLE
Add reverse connect (ReverseHello) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Reverse connect is disabled by default and is enabled by specifying one or more 
 dotnet opcplc.dll --pn=50000 --autoaccept --rcc=opc.tcp://client:65300
 ```
 
-Multiple clients are supported as a comma separated list (no spaces):
+Multiple clients are supported as a comma separated list:
 
 ```bash
 dotnet opcplc.dll --pn=50000 --autoaccept --rcc=opc.tcp://client1:65300,opc.tcp://client2:65300
@@ -562,8 +562,7 @@ Options:
       --rcc, --reverseconnectclients=VALUE
                              enable reverse connect (ReverseHello) and dial out
                                to the given client endpoint URLs, e.g. 'opc.tcp:
-                               //client:65300' (comma separated values; no
-                               spaces allowed).
+                               //client:65300' (comma separated values).
                                Default: reverse connect is disabled
       --rci, --reverseconnectinterval=VALUE
                              the interval in ms between reverse connect

--- a/README.md
+++ b/README.md
@@ -281,6 +281,29 @@ See [`src/CompanionSpecs/WotCon/README.md`](src/CompanionSpecs/WotCon/README.md)
 ## Chaos mode
 Randomly injects errors, closes subscriptions or sessions, expires subscriptions and more. You can use it to test the resiliency of OPC UA clients. To enable start the server with the option `--chaos=True`.
 
+## Reverse connect
+The server can establish the TCP connection towards the client (*ReverseHello*, see [OPC UA Part 6](https://reference.opcfoundation.org/Core/Part6/v105/docs/7.1.3)) instead of waiting for the client to connect. This is useful when the server sits behind a firewall or NAT that does not allow inbound connections.
+
+Reverse connect is disabled by default and is enabled by specifying one or more client endpoint URLs:
+
+```bash
+dotnet opcplc.dll --pn=50000 --autoaccept --rcc=opc.tcp://client:65300
+```
+
+Multiple clients are supported as a comma separated list (no spaces):
+
+```bash
+dotnet opcplc.dll --pn=50000 --autoaccept --rcc=opc.tcp://client1:65300,opc.tcp://client2:65300
+```
+
+The timing can be tuned with `--rci` (interval between connection attempts), `--rctm` (timeout waiting for a response), `--rcrt` (delay before retrying after the client rejected the connection) and `--rcms` (maximum number of concurrent sessions per client).
+
+Notes:
+- The client must be configured to accept reverse connections on the given endpoint URL and both applications must trust each other's certificate. Use `--autoaccept` and `--trustowncert` for testing.
+- The server keeps sending *ReverseHello* messages at the configured interval. If the client answers with `BadTcpMessageTypeInvalid`, i.e. it does not support or does not want reverse connections, the connection is marked as rejected and retried after `--rcrt`.
+- Because the client fetches the server certificate and then closes the channel, the first session can take up to one `--rci` interval to be established.
+- The regular server endpoint stays available, so clients can still connect to the server in the usual way.
+
 ## Other features
 - Node with special characters in name and NodeId
 - Node with long ID (3950 bytes)
@@ -536,6 +559,28 @@ Options:
       --aa, --autoaccept     all certs are trusted when a connection is
                                established.
                                Default: False
+      --rcc, --reverseconnectclients=VALUE
+                             enable reverse connect (ReverseHello) and dial out
+                               to the given client endpoint URLs, e.g. 'opc.tcp:
+                               //client:65300' (comma separated values; no
+                               spaces allowed).
+                               Default: reverse connect is disabled
+      --rci, --reverseconnectinterval=VALUE
+                             the interval in ms between reverse connect
+                               attempts.
+                               Default: 15000
+      --rctm, --reverseconnecttimeout=VALUE
+                             the timeout in ms to wait for a response to a
+                               reverse connect attempt.
+                               Default: 30000
+      --rcrt, --reverseconnectrejecttimeout=VALUE
+                             the timeout in ms before retrying a reverse
+                               connection that the client rejected.
+                               Default: 60000
+      --rcms, --reverseconnectmaxsessioncount=VALUE
+                             the maximum number of concurrent reverse connect
+                               sessions per client. 0 means unlimited.
+                               Default: 0
       --rsha1, --rejectsha1  reject SHA1 signed certificates.
                                Default: False
       --mks, --mincertkeysize=VALUE

--- a/src/Configuration/CliOptions.cs
+++ b/src/Configuration/CliOptions.cs
@@ -92,6 +92,53 @@ public static class CliOptions
             },
             { "aa|autoaccept", $"all certs are trusted when a connection is established.\nDefault: {config.OpcUa.AutoAcceptCerts}", (s) => config.OpcUa.AutoAcceptCerts = s != null },
 
+            // reverse connect configuration
+            { "rcc|reverseconnectclients=", "enable reverse connect (ReverseHello) and dial out to the given client endpoint URLs, e.g. 'opc.tcp://client:65300' (comma separated values; no spaces allowed).\nDefault: reverse connect is disabled", (s) => config.OpcUa.ReverseConnectClientUrls = ParseReverseConnectUrls(s) },
+            { "rci|reverseconnectinterval=", $"the interval in ms between reverse connect attempts.\nDefault: {config.OpcUa.ReverseConnectInterval}", (int i) => {
+                    if (i > 0)
+                    {
+                        config.OpcUa.ReverseConnectInterval = i;
+                    }
+                    else
+                    {
+                        throw new OptionException("The reverseconnectinterval must be larger than 0.", "reverseconnectinterval");
+                    }
+                }
+            },
+            { "rctm|reverseconnecttimeout=", $"the timeout in ms to wait for a response to a reverse connect attempt.\nDefault: {config.OpcUa.ReverseConnectTimeout}", (int i) => {
+                    if (i > 0)
+                    {
+                        config.OpcUa.ReverseConnectTimeout = i;
+                    }
+                    else
+                    {
+                        throw new OptionException("The reverseconnecttimeout must be larger than 0.", "reverseconnecttimeout");
+                    }
+                }
+            },
+            { "rcrt|reverseconnectrejecttimeout=", $"the timeout in ms before retrying a reverse connection that the client rejected.\nDefault: {config.OpcUa.ReverseConnectRejectTimeout}", (int i) => {
+                    if (i > 0)
+                    {
+                        config.OpcUa.ReverseConnectRejectTimeout = i;
+                    }
+                    else
+                    {
+                        throw new OptionException("The reverseconnectrejecttimeout must be larger than 0.", "reverseconnectrejecttimeout");
+                    }
+                }
+            },
+            { "rcms|reverseconnectmaxsessioncount=", $"the maximum number of concurrent reverse connect sessions per client. 0 means unlimited.\nDefault: {config.OpcUa.ReverseConnectMaxSessionCount}", (int i) => {
+                    if (i >= 0)
+                    {
+                        config.OpcUa.ReverseConnectMaxSessionCount = i;
+                    }
+                    else
+                    {
+                        throw new OptionException("The reverseconnectmaxsessioncount must be larger or equal 0.", "reverseconnectmaxsessioncount");
+                    }
+                }
+            },
+
             { "rsha1|rejectsha1", $"reject SHA1 signed certificates.\nDefault: {config.OpcUa.RejectSHA1SignedCertificates}", (s) => config.OpcUa.RejectSHA1SignedCertificates = s != null },
 
             { "mks|mincertkeysize=", $"the minimum certificate key size allowed.\nDefault: {config.OpcUa.MinimumCertificateKeySize}", (ushort i) => config.OpcUa.MinimumCertificateKeySize = i },
@@ -318,5 +365,24 @@ public static class CliOptions
             strings.Add(list);
         }
         return strings;
+    }
+
+    /// <summary>
+    /// Helper to build a validated list of reverse connect client endpoint URLs out of a comma separated list.
+    /// </summary>
+    private static List<string> ParseReverseConnectUrls(string list)
+    {
+        var urls = ParseListOfStrings(list);
+
+        foreach (string url in urls)
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out Uri uri) ||
+                !uri.Scheme.Equals(Utils.UriSchemeOpcTcp, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new OptionException($"The reverse connect client endpoint URL '{url}' is invalid, expected format: opc.tcp://<host>:<port>", "reverseconnectclients");
+            }
+        }
+
+        return urls;
     }
 }

--- a/src/Configuration/CliOptions.cs
+++ b/src/Configuration/CliOptions.cs
@@ -93,7 +93,7 @@ public static class CliOptions
             { "aa|autoaccept", $"all certs are trusted when a connection is established.\nDefault: {config.OpcUa.AutoAcceptCerts}", (s) => config.OpcUa.AutoAcceptCerts = s != null },
 
             // reverse connect configuration
-            { "rcc|reverseconnectclients=", "enable reverse connect (ReverseHello) and dial out to the given client endpoint URLs, e.g. 'opc.tcp://client:65300' (comma separated values; no spaces allowed).\nDefault: reverse connect is disabled", (s) => config.OpcUa.ReverseConnectClientUrls = ParseReverseConnectUrls(s) },
+            { "rcc|reverseconnectclients=", "enable reverse connect (ReverseHello) and dial out to the given client endpoint URLs, e.g. 'opc.tcp://client:65300' (comma separated values).\nDefault: reverse connect is disabled", (s) => config.OpcUa.ReverseConnectClientUrls = ParseReverseConnectUrls(s) },
             { "rci|reverseconnectinterval=", $"the interval in ms between reverse connect attempts.\nDefault: {config.OpcUa.ReverseConnectInterval}", (int i) => {
                     if (i > 0)
                     {
@@ -372,12 +372,20 @@ public static class CliOptions
     /// </summary>
     private static List<string> ParseReverseConnectUrls(string list)
     {
+        // ParseListOfStrings indexes into the value, so an empty option value has to be rejected up front.
+        if (string.IsNullOrWhiteSpace(list))
+        {
+            throw new OptionException("The reverseconnectclients option requires at least one client endpoint URL, expected format: opc.tcp://<host>:<port>", "reverseconnectclients");
+        }
+
         var urls = ParseListOfStrings(list);
 
         foreach (string url in urls)
         {
             if (!Uri.TryCreate(url, UriKind.Absolute, out Uri uri) ||
-                !uri.Scheme.Equals(Utils.UriSchemeOpcTcp, StringComparison.OrdinalIgnoreCase))
+                !uri.Scheme.Equals(Utils.UriSchemeOpcTcp, StringComparison.OrdinalIgnoreCase) ||
+                string.IsNullOrEmpty(uri.Host) ||
+                uri.Port <= 0)
             {
                 throw new OptionException($"The reverse connect client endpoint URL '{url}' is invalid, expected format: opc.tcp://<host>:<port>", "reverseconnectclients");
             }

--- a/src/Configuration/OpcApplicationConfiguration.cs
+++ b/src/Configuration/OpcApplicationConfiguration.cs
@@ -1,6 +1,8 @@
 namespace OpcPlc.Configuration;
 
 using Opc.Ua;
+using Opc.Ua.Server;
+using System.Collections.Generic;
 
 /// <summary>
 /// Class for OPC Application configuration.
@@ -50,6 +52,32 @@ public partial class OpcApplicationConfiguration
     /// Sets the LDS registration interval in milliseconds.
     /// </summary>
     public int LdsRegistrationInterval { get; set; }
+
+    /// <summary>
+    /// Client endpoint URLs the server reverse connects (ReverseHello) to.
+    /// An empty list disables reverse connect.
+    /// </summary>
+    public List<string> ReverseConnectClientUrls { get; set; } = [];
+
+    /// <summary>
+    /// Interval in milliseconds between reverse connect attempts.
+    /// </summary>
+    public int ReverseConnectInterval { get; set; } = ReverseConnectServer.DefaultReverseConnectInterval;
+
+    /// <summary>
+    /// Timeout in milliseconds to wait for a response to a reverse connect attempt.
+    /// </summary>
+    public int ReverseConnectTimeout { get; set; } = ReverseConnectServer.DefaultReverseConnectTimeout;
+
+    /// <summary>
+    /// Timeout in milliseconds before retrying a reverse connection that the client rejected.
+    /// </summary>
+    public int ReverseConnectRejectTimeout { get; set; } = ReverseConnectServer.DefaultReverseConnectRejectTimeout;
+
+    /// <summary>
+    /// Maximum number of concurrent reverse connect sessions per client. 0 means unlimited.
+    /// </summary>
+    public int ReverseConnectMaxSessionCount { get; set; }
 
     /// <summary>
     /// Set the max string length the OPC stack supports.

--- a/src/Configuration/OpcUaAppConfigFactory.cs
+++ b/src/Configuration/OpcUaAppConfigFactory.cs
@@ -140,6 +140,8 @@ public partial class OpcUaAppConfigFactory(
 
         LogLdsRegistrationInterval(_config.OpcUa.LdsRegistrationInterval);
 
+        ConfigureReverseConnect();
+
         // Determine if custom certificate was provided via command line
         bool customCertificateProvided = !string.IsNullOrEmpty(_config.OpcUa.NewCertificateBase64String) ||
                                          !string.IsNullOrEmpty(_config.OpcUa.NewCertificateFileName);
@@ -202,6 +204,44 @@ public partial class OpcUaAppConfigFactory(
             _config.OpcUa.ApplicationConfiguration.ServerConfiguration.MaxSubscriptionCount);
 
         return _config.OpcUa.ApplicationConfiguration;
+    }
+
+    /// <summary>
+    /// Configures reverse connect (ReverseHello) if at least one client endpoint URL is configured.
+    /// </summary>
+    private void ConfigureReverseConnect()
+    {
+        List<string> clientUrls = _config.OpcUa.ReverseConnectClientUrls;
+
+        if (clientUrls is null || clientUrls.Count == 0)
+        {
+            return;
+        }
+
+        var reverseConnect = new ReverseConnectServerConfiguration {
+            ConnectInterval = _config.OpcUa.ReverseConnectInterval,
+            ConnectTimeout = _config.OpcUa.ReverseConnectTimeout,
+            RejectTimeout = _config.OpcUa.ReverseConnectRejectTimeout,
+            Clients = [],
+        };
+
+        foreach (string clientUrl in clientUrls)
+        {
+            reverseConnect.Clients.Add(new ReverseConnectClient {
+                EndpointUrl = clientUrl,
+                Timeout = _config.OpcUa.ReverseConnectTimeout,
+                MaxSessionCount = _config.OpcUa.ReverseConnectMaxSessionCount,
+                Enabled = true,
+            });
+        }
+
+        _config.OpcUa.ApplicationConfiguration.ServerConfiguration.ReverseConnect = reverseConnect;
+
+        LogReverseConnectEnabled(
+            clientUrls,
+            _config.OpcUa.ReverseConnectInterval,
+            _config.OpcUa.ReverseConnectTimeout,
+            _config.OpcUa.ReverseConnectRejectTimeout);
     }
 
     private void ConfigureUserTokenPolicies(IApplicationConfigurationBuilderServerSelected serverBuilder)
@@ -738,6 +778,9 @@ public partial class OpcUaAppConfigFactory(
 
     [LoggerMessage(Level = LogLevel.Information, Message = "LDS(-ME) registration interval set to {LdsRegistrationInterval} ms (0 means no registration)")]
     partial void LogLdsRegistrationInterval(int ldsRegistrationInterval);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Reverse connect enabled for client endpoints {ClientUrls} with connect interval {ConnectInterval} ms, connect timeout {ConnectTimeout} ms and reject timeout {RejectTimeout} ms")]
+    partial void LogReverseConnectEnabled(IEnumerable<string> clientUrls, int connectInterval, int connectTimeout, int rejectTimeout);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "No existing application certificate found. Creating a self-signed application certificate valid since yesterday for {DefaultLifeTime} months, with a {DefaultKeySize} bit key and {DefaultHashSize} bit hash")]
     partial void LogNoExistingCertificateFound(ushort defaultLifeTime, ushort defaultKeySize, ushort defaultHashSize);

--- a/src/OpcPlcServer.cs
+++ b/src/OpcPlcServer.cs
@@ -151,6 +151,12 @@ public partial class OpcPlcServer
 
             await StartPlcServerAsync(cancellationToken).ConfigureAwait(false);
         }
+        catch (Mono.Options.OptionException ex)
+        {
+            LogInvalidOption(ex.Message);
+            LogUsageHelp(CliOptions.GetUsageHelp(Config.ProgramName));
+            Environment.ExitCode = 1;
+        }
         catch (Exception ex)
         {
             LogServerFailedUnexpectedly(ex);
@@ -450,6 +456,9 @@ public partial class OpcPlcServer
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Found one or more invalid command line arguments: {InvalidArgs}")]
     partial void LogInvalidArgs(string invalidArgs);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Invalid command line option: {Message}")]
+    partial void LogInvalidOption(string message);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Min worker threads: {MinWorkerThreads}, min completion port threads: {MinCompletionPortThreads}")]
     partial void LogMinWorkerThreads(int minWorkerThreads, int minCompletionPortThreads);

--- a/src/PlcServer.cs
+++ b/src/PlcServer.cs
@@ -22,7 +22,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
-public partial class PlcServer : StandardServer
+public partial class PlcServer : ReverseConnectServer
 {
     private const uint PlcShutdownWaitSeconds = 10;
     private const int PeriodicLoggingTimerSeconds = 60;

--- a/tests/Configuration/CliOptionsReverseConnectTests.cs
+++ b/tests/Configuration/CliOptionsReverseConnectTests.cs
@@ -63,6 +63,9 @@ public class CliOptionsReverseConnectTests
     [TestCase("not-a-valid-url")]
     [TestCase("http://client:65300")]
     [TestCase("opc.tcp://client1:65300,bogus")]
+    [TestCase("opc.tcp://client")]
+    [TestCase("opc.tcp://:65300")]
+    [TestCase("opc.tcp://")]
     public void Parse_ReverseConnectClients_InvalidUrl_Throws(string value)
     {
         // Arrange
@@ -74,7 +77,37 @@ public class CliOptionsReverseConnectTests
 
         // Assert
         act.Should().Throw<Mono.Options.OptionException>()
-            .WithMessage("*is invalid, expected format: opc.tcp://<host>:<port>*");
+            .WithMessage("*expected format: opc.tcp://<host>:<port>*");
+    }
+
+    [TestCase("")]
+    [TestCase("   ")]
+    public void Parse_ReverseConnectClients_EmptyValue_ThrowsOptionException(string value)
+    {
+        // Arrange
+        var config = new OpcPlcConfiguration();
+        var args = new[] { $"--rcc={value}" };
+
+        // Act
+        var act = () => CliOptions.InitConfiguration(args, config, NoPluginNodes);
+
+        // Assert
+        act.Should().Throw<Mono.Options.OptionException>("an empty value must not escape as an IndexOutOfRangeException");
+    }
+
+    [Test]
+    public void Parse_ReverseConnectClients_TrimsSpacesAroundUrls()
+    {
+        // Arrange
+        var config = new OpcPlcConfiguration();
+        var args = new[] { "--rcc=opc.tcp://client1:65300, opc.tcp://client2:65301" };
+
+        // Act
+        _ = CliOptions.InitConfiguration(args, config, NoPluginNodes);
+
+        // Assert
+        config.OpcUa.ReverseConnectClientUrls.Should()
+            .Equal("opc.tcp://client1:65300", "opc.tcp://client2:65301");
     }
 
     [Test]

--- a/tests/Configuration/CliOptionsReverseConnectTests.cs
+++ b/tests/Configuration/CliOptionsReverseConnectTests.cs
@@ -1,0 +1,113 @@
+namespace OpcPlc.Tests.Configuration;
+
+using FluentAssertions;
+using NUnit.Framework;
+using OpcPlc.Configuration;
+using System;
+using System.Collections.Immutable;
+
+[TestFixture]
+public class CliOptionsReverseConnectTests
+{
+    private static ImmutableList<OpcPlc.PluginNodes.Models.IPluginNodes> NoPluginNodes
+        => ImmutableList<OpcPlc.PluginNodes.Models.IPluginNodes>.Empty;
+
+    [Test]
+    public void Parse_ReverseConnect_IsDisabledByDefault()
+    {
+        // Arrange
+        var config = new OpcPlcConfiguration();
+        var args = Array.Empty<string>();
+
+        // Act
+        _ = CliOptions.InitConfiguration(args, config, NoPluginNodes);
+
+        // Assert
+        config.OpcUa.ReverseConnectClientUrls.Should().BeEmpty();
+        config.OpcUa.ReverseConnectInterval.Should().Be(15_000);
+        config.OpcUa.ReverseConnectTimeout.Should().Be(30_000);
+        config.OpcUa.ReverseConnectRejectTimeout.Should().Be(60_000);
+        config.OpcUa.ReverseConnectMaxSessionCount.Should().Be(0);
+    }
+
+    [Test]
+    public void Parse_ReverseConnectClients_PopulatesSingleUrl()
+    {
+        // Arrange
+        var config = new OpcPlcConfiguration();
+        var args = new[] { "--rcc=opc.tcp://client:65300" };
+
+        // Act
+        _ = CliOptions.InitConfiguration(args, config, NoPluginNodes);
+
+        // Assert
+        config.OpcUa.ReverseConnectClientUrls.Should().ContainSingle()
+            .Which.Should().Be("opc.tcp://client:65300");
+    }
+
+    [Test]
+    public void Parse_ReverseConnectClients_PopulatesMultipleUrls()
+    {
+        // Arrange
+        var config = new OpcPlcConfiguration();
+        var args = new[] { "--reverseconnectclients=opc.tcp://client1:65300,opc.tcp://client2:65301" };
+
+        // Act
+        _ = CliOptions.InitConfiguration(args, config, NoPluginNodes);
+
+        // Assert
+        config.OpcUa.ReverseConnectClientUrls.Should()
+            .Equal("opc.tcp://client1:65300", "opc.tcp://client2:65301");
+    }
+
+    [TestCase("not-a-valid-url")]
+    [TestCase("http://client:65300")]
+    [TestCase("opc.tcp://client1:65300,bogus")]
+    public void Parse_ReverseConnectClients_InvalidUrl_Throws(string value)
+    {
+        // Arrange
+        var config = new OpcPlcConfiguration();
+        var args = new[] { $"--rcc={value}" };
+
+        // Act
+        var act = () => CliOptions.InitConfiguration(args, config, NoPluginNodes);
+
+        // Assert
+        act.Should().Throw<Mono.Options.OptionException>()
+            .WithMessage("*is invalid, expected format: opc.tcp://<host>:<port>*");
+    }
+
+    [Test]
+    public void Parse_ReverseConnectTimings_SetConfigValues()
+    {
+        // Arrange
+        var config = new OpcPlcConfiguration();
+        var args = new[] { "--rci=1000", "--rctm=2000", "--rcrt=3000", "--rcms=4" };
+
+        // Act
+        _ = CliOptions.InitConfiguration(args, config, NoPluginNodes);
+
+        // Assert
+        config.OpcUa.ReverseConnectInterval.Should().Be(1000);
+        config.OpcUa.ReverseConnectTimeout.Should().Be(2000);
+        config.OpcUa.ReverseConnectRejectTimeout.Should().Be(3000);
+        config.OpcUa.ReverseConnectMaxSessionCount.Should().Be(4);
+    }
+
+    [TestCase("--rci=0")]
+    [TestCase("--rctm=0")]
+    [TestCase("--rcrt=0")]
+    [TestCase("--rcms=-1")]
+    public void Parse_ReverseConnectTimings_OutOfRange_Throws(string arg)
+    {
+        // Arrange
+        var config = new OpcPlcConfiguration();
+        var args = new[] { arg };
+
+        // Act
+        var act = () => CliOptions.InitConfiguration(args, config, NoPluginNodes);
+
+        // Assert
+        act.Should().Throw<Mono.Options.OptionException>();
+    }
+}

--- a/tests/Configuration/OpcUaAppConfigFactoryTests.cs
+++ b/tests/Configuration/OpcUaAppConfigFactoryTests.cs
@@ -10,6 +10,7 @@ using OpcPlc.Helpers;
 using Opc.Ua.Security.Certificates;
 using System;
 using System.IO;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -455,5 +456,95 @@ public class OpcUaAppConfigFactoryTests
         {
             try { Directory.Delete(root, recursive: true); } catch { };
         }
+    }
+
+    [Test]
+    public async Task ConfigureAsync_ReverseConnectNotConfigured_LeavesReverseConnectUnset()
+    {
+        // Arrange
+        string root = Path.Combine(Path.GetTempPath(), "opcplc_test_pki_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var config = CreateConfigWithTempStores(root);
+
+            var loggerMock = new Mock<ILogger>();
+            var loggerFactoryMock = new Mock<ILoggerFactory>();
+            loggerFactoryMock.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(loggerMock.Object);
+            var telemetryContext = new OpcTelemetryContext(loggerFactoryMock.Object, "Opc.Ua", OpcTelemetryContext.ResolveOpcPlcVersion());
+
+            var factory = new OpcUaAppConfigFactory(config, loggerMock.Object, loggerFactoryMock.Object, telemetryContext);
+
+            // Act
+            var appConfig = await factory.ConfigureAsync().ConfigureAwait(false);
+
+            // Assert
+            appConfig.ServerConfiguration.ReverseConnect.Should().BeNull();
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { };
+        }
+    }
+
+    [Test]
+    public async Task ConfigureAsync_ReverseConnectConfigured_PopulatesServerConfiguration()
+    {
+        // Arrange
+        string root = Path.Combine(Path.GetTempPath(), "opcplc_test_pki_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var config = CreateConfigWithTempStores(root);
+            config.OpcUa.ReverseConnectClientUrls = ["opc.tcp://client1:65300", "opc.tcp://client2:65301"];
+            config.OpcUa.ReverseConnectInterval = 1000;
+            config.OpcUa.ReverseConnectTimeout = 2000;
+            config.OpcUa.ReverseConnectRejectTimeout = 3000;
+            config.OpcUa.ReverseConnectMaxSessionCount = 4;
+
+            var loggerMock = new Mock<ILogger>();
+            var loggerFactoryMock = new Mock<ILoggerFactory>();
+            loggerFactoryMock.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(loggerMock.Object);
+            var telemetryContext = new OpcTelemetryContext(loggerFactoryMock.Object, "Opc.Ua", OpcTelemetryContext.ResolveOpcPlcVersion());
+
+            var factory = new OpcUaAppConfigFactory(config, loggerMock.Object, loggerFactoryMock.Object, telemetryContext);
+
+            // Act
+            var appConfig = await factory.ConfigureAsync().ConfigureAwait(false);
+
+            // Assert
+            var reverseConnect = appConfig.ServerConfiguration.ReverseConnect;
+            reverseConnect.Should().NotBeNull();
+            reverseConnect.ConnectInterval.Should().Be(1000);
+            reverseConnect.ConnectTimeout.Should().Be(2000);
+            reverseConnect.RejectTimeout.Should().Be(3000);
+
+            reverseConnect.Clients.Should().HaveCount(2);
+            reverseConnect.Clients.Select(c => c.EndpointUrl).Should()
+                .Equal("opc.tcp://client1:65300", "opc.tcp://client2:65301");
+            reverseConnect.Clients.Should().OnlyContain(c => c.Enabled);
+            reverseConnect.Clients.Should().OnlyContain(c => c.Timeout == 2000);
+            reverseConnect.Clients.Should().OnlyContain(c => c.MaxSessionCount == 4);
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { };
+        }
+    }
+
+    private static OpcPlcConfiguration CreateConfigWithTempStores(string root)
+    {
+        var config = new OpcPlcConfiguration();
+        config.OpcUa.OpcOwnCertStoreType = FlatDirectoryCertificateStore.StoreTypeName;
+        config.OpcUa.OpcOwnCertStorePath = Path.Combine(root, "own");
+        config.OpcUa.OpcTrustedCertStorePath = Path.Combine(root, "trusted");
+        config.OpcUa.OpcRejectedCertStorePath = Path.Combine(root, "rejected");
+        config.OpcUa.OpcIssuerCertStorePath = Path.Combine(root, "issuer");
+        config.OpcUa.OpcTrustedUserCertStorePath = Path.Combine(root, "trusted-user");
+        config.OpcUa.OpcUserIssuerCertStorePath = Path.Combine(root, "issuer-user");
+
+        Directory.CreateDirectory(config.OpcUa.OpcOwnCertStorePath);
+
+        return config;
     }
 }

--- a/tests/ReverseConnectTests.cs
+++ b/tests/ReverseConnectTests.cs
@@ -1,0 +1,140 @@
+namespace OpcPlc.Tests;
+
+using FluentAssertions;
+using NUnit.Framework;
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Tests for the reverse connect (ReverseHello) feature.
+/// These start their own server instance, since reverse connect must be configured at startup.
+/// </summary>
+[TestFixture]
+public class ReverseConnectTests
+{
+    /// <summary>
+    /// The OPC UA TCP message type that a server sends to a reverse connect client.
+    /// </summary>
+    private const string ReverseHelloMessageType = "RHE";
+
+    private const int ReverseConnectIntervalMs = 1000;
+
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(60);
+
+    [Test]
+    public async Task ReverseConnect_SendsReverseHelloToConfiguredClient()
+    {
+        // Arrange: a plain TCP listener that stands in for the reverse connect client.
+        var clientListener = new TcpListener(IPAddress.Loopback, 0);
+        clientListener.Start();
+        int clientPort = ((IPEndPoint)clientListener.LocalEndpoint).Port;
+
+        var opcPlcServer = new OpcPlcServer();
+        using var serverCts = new CancellationTokenSource();
+
+        var serverTask = Task.Run(() => opcPlcServer.StartAsync(
+            [
+                "--autoaccept",
+                $"--pn={GetFreePort()}",
+                $"--rcc=opc.tcp://localhost:{clientPort}",
+                $"--rci={ReverseConnectIntervalMs}",
+            ],
+            serverCts.Token));
+
+        try
+        {
+            await WaitForServerReadyAsync(opcPlcServer, serverTask).ConfigureAwait(false);
+
+            opcPlcServer.PlcServer.GetReverseConnections().Keys
+                .Should().Contain(url => url.Port == clientPort,
+                    "the configured client endpoint should be registered as a reverse connection");
+
+            // Act: the server dials out to the client endpoint on its own.
+            using var timeoutCts = new CancellationTokenSource(Timeout);
+            using var connection = await clientListener.AcceptTcpClientAsync(timeoutCts.Token).ConfigureAwait(false);
+
+            var buffer = new byte[8];
+            int read = await connection.GetStream()
+                .ReadAtLeastAsync(buffer, ReverseHelloMessageType.Length, throwOnEndOfStream: false, timeoutCts.Token)
+                .ConfigureAwait(false);
+
+            // Assert
+            read.Should().BeGreaterThanOrEqualTo(ReverseHelloMessageType.Length);
+            Encoding.ASCII.GetString(buffer, 0, ReverseHelloMessageType.Length)
+                .Should().Be(ReverseHelloMessageType, "the server must greet the client with a ReverseHello message");
+        }
+        finally
+        {
+            clientListener.Stop();
+            await StopServerAsync(serverCts, serverTask).ConfigureAwait(false);
+        }
+    }
+
+    [Test]
+    public async Task ReverseConnect_NotConfigured_HasNoReverseConnections()
+    {
+        // Arrange
+        var opcPlcServer = new OpcPlcServer();
+        using var serverCts = new CancellationTokenSource();
+
+        var serverTask = Task.Run(() => opcPlcServer.StartAsync(
+            [
+                "--autoaccept",
+                $"--pn={GetFreePort()}",
+            ],
+            serverCts.Token));
+
+        try
+        {
+            // Act
+            await WaitForServerReadyAsync(opcPlcServer, serverTask).ConfigureAwait(false);
+
+            // Assert
+            opcPlcServer.PlcServer.GetReverseConnections().Should().BeEmpty();
+        }
+        finally
+        {
+            await StopServerAsync(serverCts, serverTask).ConfigureAwait(false);
+        }
+    }
+
+    private static int GetFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static async Task WaitForServerReadyAsync(OpcPlcServer opcPlcServer, Task serverTask)
+    {
+        using var timeoutCts = new CancellationTokenSource(Timeout);
+
+        while (!opcPlcServer.Ready)
+        {
+            if (serverTask.IsFaulted)
+            {
+                throw serverTask.Exception!;
+            }
+
+            if (serverTask.IsCompleted)
+            {
+                throw new InvalidOperationException("The OPC PLC server failed to start.");
+            }
+
+            timeoutCts.Token.ThrowIfCancellationRequested();
+            await Task.Delay(200).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task StopServerAsync(CancellationTokenSource serverCts, Task serverTask)
+    {
+        await serverCts.CancelAsync().ConfigureAwait(false);
+        await Task.WhenAny(serverTask, Task.Delay(Timeout)).ConfigureAwait(false);
+    }
+}

--- a/tests/ReverseConnectTests.cs
+++ b/tests/ReverseConnectTests.cs
@@ -59,7 +59,7 @@ public class ReverseConnectTests
 
             var buffer = new byte[8];
             int read = await connection.GetStream()
-                .ReadAtLeastAsync(buffer, ReverseHelloMessageType.Length, throwOnEndOfStream: false, timeoutCts.Token)
+                .ReadAtLeastAsync(buffer, ReverseHelloMessageType.Length, throwOnEndOfStream: false, cancellationToken: timeoutCts.Token)
                 .ConfigureAwait(false);
 
             // Assert

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.14.22",
+  "version": "2.14.23",
   "versionHeightOffset": -1,
   "publicReleaseRefSpec": [
     "^refs/heads/main$",


### PR DESCRIPTION
## Purpose
The server can now establish the TCP connection towards the client instead of waiting for an inbound connection, which is needed when OPC PLC runs behind a firewall or NAT.

PlcServer now derives from the SDK's ReverseConnectServer, and the configured client endpoints are applied to ServerConfiguration.ReverseConnect. The feature is opt-in: without --rcc no reverse connect configuration is created and the behavior is unchanged.

New command line options:
  --rcc  reverse connect client endpoint URLs (comma separated)
  --rci  interval between reverse connect attempts
  --rctm timeout waiting for a response
  --rcrt timeout before retrying after the client rejected the connection
  --rcms maximum concurrent reverse connect sessions per client

Also fix invalid command line values crashing with an unhandled AggregateException. OptionException is now caught during startup, logging the error and usage help and exiting with code 1. This applies to all validating options, not just the new ones.

Adds 15 tests covering option parsing, application configuration and an end-to-end check that the server sends a ReverseHello to a listening client.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->