### PR TITLE
Remove default usernames and passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,10 +378,11 @@ X.509 certificates:
 GDS push service support:
 
 * OPC PLC exposes the standard OPC UA Server Configuration methods used by GDS push (for example `CreateSigningRequest`, `GetRejectedList`, `UpdateCertificate`, and `ApplyChanges`).
-* Access to these methods follows OPC UA security requirements: use a secure endpoint (`Sign & Encrypt`) and administrator credentials (`--au` / `--ac`, defaults: `sysadmin` / `demo`).
+* Access to these methods follows OPC UA security requirements: use a secure endpoint (`Sign & Encrypt`) and administrator credentials. There are no built-in credentials: an admin account only exists when you supply one with `--au` / `--ac`.
 * GDS push works with `Directory`, `FlatDirectory`, and `KubernetesSecret` certificate store modes.
 
-Short example (C# with OPC Foundation GDS client):
+Short example (C# with OPC Foundation GDS client), assuming the server was started with
+`--au myadmin --ac <your-password>`:
 
 ~~~csharp
 using Opc.Ua;
@@ -392,8 +393,8 @@ var client = new ServerPushConfigurationClient(appConfig)
 {
   AdminCredentials = new UserIdentity(new UserNameIdentityToken
   {
-    UserName = "sysadmin",
-    DecryptedPassword = Encoding.UTF8.GetBytes("demo")
+    UserName = "myadmin",
+    DecryptedPassword = Encoding.UTF8.GetBytes("<your-password>")
   })
 };
 
@@ -423,6 +424,13 @@ CLI start example for KubernetesSecret mode:
 ~~~powershell
 dotnet opcplc.dll --at KubernetesSecret --ksns opcplc --ap pki/own --tp pki/trusted --ip pki/issuer --rp pki/rejected --tup pki/trusted-user --uip pki/issuer-user
 ~~~
+
+User authentication:
+
+* Anonymous and X.509 certificate authentication are enabled by default. Username/password authentication is **disabled** by default and there are no built-in credentials.
+* To enable it, supply your own accounts: `--au`/`--ac` for the admin user (granted the SecurityAdmin/ConfigureAdmin roles, required for GDS push) and/or `--du`/`--dc` for a non-privileged user. Each username must be supplied together with its password.
+* The server refuses to start if all authentication mechanisms are disabled, i.e. `--daa` and `--dca` are set and no username/password credentials were supplied.
+* `--dua` suppresses username/password authentication even when credentials are configured.
 
 User certificate-based authentication:
 
@@ -713,23 +721,32 @@ Options:
                              flag to disable anonymous authentication.
                                Default: False
       --dua, --disableusernamepasswordauth
-                             flag to disable username/password authentication.
-                               Default: False
+                             flag to disable username/password authentication,
+                               even when credentials are configured.
+                               Default: username/password authentication is
+                               only offered when credentials are supplied via
+                               adminuser/adminpassword or defaultuser/
+                               defaultpassword.
       --dca, --disablecertauth
                              flag to disable certificate authentication.
                                Default: False
       --au, --adminuser=VALUE
-                             the username of the admin user.
-                               Default: sysadmin
+                             the username of the admin user, which is permitted
+                               to configure the server (e.g. GDS push).
+                               Requires 'adminpassword'.
+                               Default: not set, no admin user exists.
       --ac, --adminpassword=VALUE
-                             the password of the administrator.
-                               Default: demo
+                             the password of the admin user. Requires
+                               'adminuser'.
+                               Default: not set.
       --du, --defaultuser=VALUE
-                             the username of the default user.
-                               Default: user1
+                             the username of the default, non-privileged user.
+                               Requires 'defaultpassword'.
+                               Default: not set.
       --dc, --defaultpassword=VALUE
-                             the password of the default user.
-                               Default: password
+                             the password of the default user. Requires
+                               'defaultuser'.
+                               Default: not set.
       --alm, --alarms        add alarm simulation to address space.
                                Default: False
       --ses, --simpleevents  add simple events simulation to address space.

--- a/src/Configuration/CliOptions.cs
+++ b/src/Configuration/CliOptions.cs
@@ -267,14 +267,14 @@ public static class CliOptions
             },
 
             {"daa|disableanonymousauth", $"flag to disable anonymous authentication.\nDefault: {config.DisableAnonymousAuth}", (s) => config.DisableAnonymousAuth = s != null },
-            {"dua|disableusernamepasswordauth", $"flag to disable username/password authentication.\nDefault: {config.DisableUsernamePasswordAuth}", (s) => config.DisableUsernamePasswordAuth = s != null },
+            {"dua|disableusernamepasswordauth", "flag to disable username/password authentication, even when credentials are configured.\nDefault: username/password authentication is only offered when credentials are supplied via adminuser/adminpassword or defaultuser/defaultpassword.", (s) => config.DisableUsernamePasswordAuth = s != null },
             {"dca|disablecertauth", $"flag to disable certificate authentication.\nDefault: {config.DisableCertAuth}", (s) => config.DisableCertAuth = s != null },
 
             // user management
-            { "au|adminuser=", $"the username of the admin user.\nDefault: {config.AdminUser}", (s) => config.AdminUser = s ?? config.AdminUser},
-            { "ac|adminpassword=", $"the password of the administrator.\nDefault: {config.AdminPassword}", (s) => config.AdminPassword = s ?? config.AdminPassword},
-            { "du|defaultuser=", $"the username of the default user.\nDefault: {config.DefaultUser}", (s) => config.DefaultUser = s ?? config.DefaultUser},
-            { "dc|defaultpassword=", $"the password of the default user.\nDefault: {config.DefaultPassword}", (s) => config.DefaultPassword = s ?? config.DefaultPassword},
+            { "au|adminuser=", "the username of the admin user, which is permitted to configure the server (e.g. GDS push). Requires 'adminpassword'.\nDefault: not set, no admin user exists.", (s) => config.AdminUser = s },
+            { "ac|adminpassword=", "the password of the admin user. Requires 'adminuser'.\nDefault: not set.", (s) => config.AdminPassword = s },
+            { "du|defaultuser=", "the username of the default, non-privileged user. Requires 'defaultpassword'.\nDefault: not set.", (s) => config.DefaultUser = s },
+            { "dc|defaultpassword=", "the password of the default user. Requires 'defaultuser'.\nDefault: not set.", (s) => config.DefaultPassword = s },
 
             // Special nodes
             { "alm|alarms", $"add alarm simulation to address space.\nDefault: {plcSimulation.AddAlarmSimulation}", (s) => plcSimulation.AddAlarmSimulation = s != null },
@@ -303,7 +303,36 @@ public static class CliOptions
         // Parse the command line.
         List<string> extraArgs = _options.Parse(args);
 
+        if (!config.ShowHelp)
+        {
+            ValidateAuthenticationOptions(config);
+        }
+
         return (plcSimulation, extraArgs);
+    }
+
+    /// <summary>
+    /// Rejects incomplete or unusable authentication settings, so that the server never silently
+    /// falls back to an implicit account.
+    /// </summary>
+    private static void ValidateAuthenticationOptions(OpcPlcConfiguration config)
+    {
+        if (string.IsNullOrEmpty(config.AdminUser) != string.IsNullOrEmpty(config.AdminPassword))
+        {
+            throw new OptionException("The options 'adminuser' and 'adminpassword' must be specified together.", "adminuser");
+        }
+
+        if (string.IsNullOrEmpty(config.DefaultUser) != string.IsNullOrEmpty(config.DefaultPassword))
+        {
+            throw new OptionException("The options 'defaultuser' and 'defaultpassword' must be specified together.", "defaultuser");
+        }
+
+        if (config.DisableAnonymousAuth && config.DisableCertAuth && !config.UsernamePasswordAuthEnabled)
+        {
+            throw new OptionException(
+                "No authentication mechanism is enabled. Supply credentials via 'adminuser'/'adminpassword' or 'defaultuser'/'defaultpassword', or enable anonymous or certificate authentication.",
+                "disableanonymousauth");
+        }
     }
 
     /// <summary>

--- a/src/Configuration/Configuration.cs
+++ b/src/Configuration/Configuration.cs
@@ -11,29 +11,50 @@ public class OpcPlcConfiguration
 
     public bool DisableAnonymousAuth { get; set; }
 
+    /// <summary>
+    /// Suppresses username/password authentication even when credentials are configured.
+    /// </summary>
     public bool DisableUsernamePasswordAuth { get; set; }
 
     public bool DisableCertAuth { get; set; }
 
     /// <summary>
-    /// Admin user.
+    /// Admin user, which is granted the SecurityAdmin/ConfigureAdmin roles. Not set by default:
+    /// the server has no built-in admin account.
     /// </summary>
-    public string AdminUser { get; set; } = "sysadmin";
+    public string AdminUser { get; set; }
 
     /// <summary>
-    /// Admin user password.
+    /// Admin user password. Not set by default.
     /// </summary>
-    public string AdminPassword { get; set; } = "demo";
+    public string AdminPassword { get; set; }
 
     /// <summary>
-    /// Default user.
+    /// Default, non-privileged user. Not set by default.
     /// </summary>
-    public string DefaultUser { get; set; } = "user1";
+    public string DefaultUser { get; set; }
 
     /// <summary>
-    /// Default user password.
+    /// Default user password. Not set by default.
     /// </summary>
-    public string DefaultPassword { get; set; } = "password";
+    public string DefaultPassword { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether a privileged admin account is configured.
+    /// </summary>
+    public bool HasAdminCredentials => !string.IsNullOrEmpty(AdminUser) && !string.IsNullOrEmpty(AdminPassword);
+
+    /// <summary>
+    /// Gets a value indicating whether a non-privileged user account is configured.
+    /// </summary>
+    public bool HasDefaultUserCredentials => !string.IsNullOrEmpty(DefaultUser) && !string.IsNullOrEmpty(DefaultPassword);
+
+    /// <summary>
+    /// Gets a value indicating whether the username/password user token policy is offered.
+    /// It is only offered when credentials were explicitly configured, so that the server never
+    /// accepts well-known default credentials.
+    /// </summary>
+    public bool UsernamePasswordAuthEnabled => !DisableUsernamePasswordAuth && (HasAdminCredentials || HasDefaultUserCredentials);
 
     /// <summary>
     /// Gets or sets OTLP reporting endpoint URI.

--- a/src/Configuration/OpcUaAppConfigFactory.cs
+++ b/src/Configuration/OpcUaAppConfigFactory.cs
@@ -251,7 +251,7 @@ public partial class OpcUaAppConfigFactory(
             serverBuilder.AddUserTokenPolicy(new UserTokenPolicy(UserTokenType.Anonymous));
         }
 
-        if (!_config.DisableUsernamePasswordAuth)
+        if (_config.UsernamePasswordAuthEnabled)
         {
             serverBuilder.AddUserTokenPolicy(new UserTokenPolicy(UserTokenType.UserName));
         }

--- a/src/OpcPlcServer.cs
+++ b/src/OpcPlcServer.cs
@@ -328,7 +328,7 @@ public partial class OpcPlcServer
 
         LogAnonymousAuth(Config.DisableAnonymousAuth ? "Disabled" : "Enabled");
         LogRejectUnknownRevocationStatus(Config.OpcUa.DontRejectUnknownRevocationStatus ? "Disabled" : "Enabled");
-        LogUsernamePasswordAuth(Config.DisableUsernamePasswordAuth ? "Disabled" : "Enabled");
+        LogUsernamePasswordAuth(Config.UsernamePasswordAuthEnabled ? "Enabled" : "Disabled");
         LogCertAuth(Config.DisableCertAuth ? "Disabled" : "Enabled");
 
         // Add simple events, alarms, reference test simulation and deterministic alarms.

--- a/src/UserAuthentication.cs
+++ b/src/UserAuthentication.cs
@@ -62,16 +62,21 @@ public partial class PlcServer
                 "Security token is not a valid username token. An empty password is not accepted.");
         }
 
-        // user with permission to configure server
-        if (userName == Config.AdminUser && password == Config.AdminPassword)
+        // User with permission to configure the server. The account only exists when admin
+        // credentials were explicitly configured; there is no built-in admin account.
+        if (Config.HasAdminCredentials &&
+            userName == Config.AdminUser &&
+            password == Config.AdminPassword)
         {
             return new SystemConfigurationIdentity(new UserIdentity(userNameToken));
         }
 
-        // standard users for CTT verification
-        if (!(userName == Config.DefaultUser && password == Config.DefaultPassword))
+        // Standard user, e.g. for CTT verification.
+        if (!Config.HasDefaultUserCredentials ||
+            userName != Config.DefaultUser ||
+            password != Config.DefaultPassword)
         {
-              // create an exception with a vendor defined sub-code.
+            // create an exception with a vendor defined sub-code.
             throw ServiceResultException.Create(
                 StatusCodes.BadUserAccessDenied,
                 "Invalid username or password.");

--- a/tests/GdsPushConfigurationFlatDirectoryTests.cs
+++ b/tests/GdsPushConfigurationFlatDirectoryTests.cs
@@ -23,6 +23,10 @@ public class GdsPushConfigurationFlatDirectoryTests
 
         _simulator = new PlcSimulatorFixture(
         [
+            "--au=sysadmin",
+            "--ac=demo",
+            "--du=user1",
+            "--dc=password",
             "--at=FlatDirectory",
             $"--ap={_appStorePath}",
             $"--tp={Path.Combine(_storeRootPath, "trusted")}",

--- a/tests/GdsPushConfigurationTests.cs
+++ b/tests/GdsPushConfigurationTests.cs
@@ -12,7 +12,12 @@ using System.Threading.Tasks;
 [TestFixture]
 public class GdsPushConfigurationTests
 {
-    private readonly PlcSimulatorFixture _simulator = new([]);
+    private readonly PlcSimulatorFixture _simulator = new([
+        "--au=sysadmin",
+        "--ac=demo",
+        "--du=user1",
+        "--dc=password",
+    ]);
 
     [OneTimeSetUp]
     public async Task SetupAsync()

--- a/tests/UserAuthenticationTests.cs
+++ b/tests/UserAuthenticationTests.cs
@@ -84,6 +84,24 @@ public class UserAuthenticationTests
     }
 
     [Test]
+    public void SessionManager_ImpersonateUser_RejectsUsernameToken_WhenNoCredentialsAreConfigured()
+    {
+        using var testContext = new TestServerContext(configureCredentials: false);
+
+        var args = CreateImpersonateEventArgs(new UserNameIdentityToken
+        {
+            UserName = "sysadmin",
+            DecryptedPassword = System.Text.Encoding.UTF8.GetBytes("demo")
+        });
+
+        Action act = () => InvokeImpersonateUser(testContext.Server, args);
+
+        act.Should()
+            .Throw<ServiceResultException>()
+            .Where(e => e.StatusCode == StatusCodes.BadUserAccessDenied);
+    }
+
+    [Test]
     public void SessionManager_ImpersonateUser_RejectsUnsupportedTokenType()
     {
         using var testContext = new TestServerContext();
@@ -215,9 +233,18 @@ public class UserAuthenticationTests
         private readonly ILoggerFactory _loggerFactory;
         private readonly OpcTelemetryContext _telemetryContext;
 
-        public TestServerContext()
+        public TestServerContext(bool configureCredentials = true)
         {
             Config = new OpcPlcConfiguration();
+
+            if (configureCredentials)
+            {
+                Config.AdminUser = "test-admin";
+                Config.AdminPassword = "test-admin-password";
+                Config.DefaultUser = "test-user";
+                Config.DefaultPassword = "test-user-password";
+            }
+
             _loggerFactory = LoggerFactory.Create(_ => { });
             ILogger logger = _loggerFactory.CreateLogger<PlcServer>();
             _telemetryContext = new OpcTelemetryContext(_loggerFactory, "OpcPlc", "test");

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.14.23",
+  "version": "2.14.24",
   "versionHeightOffset": -1,
   "publicReleaseRefSpec": [
     "^refs/heads/main$",

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.14.24",
+  "version": "2.15.1",
   "versionHeightOffset": -1,
   "publicReleaseRefSpec": [
     "^refs/heads/main$",


### PR DESCRIPTION
* The server no longer ships with the well-known sysadmin/demo and user1/password accounts
* Username/password authentication is now only offered when credentials are explicitly supplied, the privileged admin identity (SecurityAdmin/ConfigureAdmin, used for GDS push) only exists when --au/--ac are given, and the server fails fast with a clear message on incomplete credential pairs or when no authentication mechanism is enabled at all
* The --help output no longer echoes passwords

⚠️ Breaking change
* Clients that relied on the default accounts will now get BadIdentityTokenRejected (the UserName token policy is not advertised)
* To restore the previous behavior, start the server with your own credentials, e.g. --au=sysadmin --ac=demo --du=user1 --dc=password, ideally replacing those values with non-default ones
* Note that --au/--ac and --du/--dc must each be supplied as a pair, and --daa --dca without any credentials is now rejected at startup