### PR TITLE
Add missing ModelChangeEvent when WoT createAsset, createAssetForEndp…

### DIFF
--- a/src/CompanionSpecs/WotCon/WotConNodeManager.cs
+++ b/src/CompanionSpecs/WotCon/WotConNodeManager.cs
@@ -545,6 +545,7 @@ public partial class WotConNodeManager : CustomNodeManager2
                 "[WotCon] Created WoT asset '{AssetName}' with AssetId {AssetId} and WoTFile {FileId}{EndpointSuffix}",
                 assetName, asset.AssetId, asset.FileNodeId,
                 string.IsNullOrWhiteSpace(endpoint) ? string.Empty : $" (endpoint={endpoint})");
+            ReportAssetModelChange(context, asset.AssetId, ModelChangeStructureVerbMask.NodeAdded);
             return (ServiceResult.Good, asset.AssetId);
         }
         catch (Exception ex)
@@ -603,6 +604,7 @@ public partial class WotConNodeManager : CustomNodeManager2
             // Setting IsDeleted under the lock means a CloseAndUpdate that wins the lock
             // after we release will short-circuit instead of writing into the address-space
             // subtree we're about to remove.
+            bool deleted;
             lock (asset.LifecycleLock)
             {
                 asset.IsDeleted = true;
@@ -628,7 +630,7 @@ public partial class WotConNodeManager : CustomNodeManager2
                 // DeleteNode recursively removes the asset and all HasComponent children
                 // (the per-asset WoTFile + its standard FileType properties and methods,
                 // plus any materialized TD properties).
-                bool deleted = DeleteNode(SystemContext, assetId);
+                deleted = DeleteNode(SystemContext, assetId);
 
                 _assets.TryRemove(assetName, out _);
                 if (asset.FileNodeId != null)
@@ -643,6 +645,11 @@ public partial class WotConNodeManager : CustomNodeManager2
             }
 
             _logger?.LogInformation("[WotCon] Deleted WoT asset '{AssetName}' AssetId={AssetId}", assetName, assetId);
+            if (deleted)
+            {
+                ReportAssetModelChange(context, assetId, ModelChangeStructureVerbMask.NodeDeleted);
+            }
+
             return ServiceResult.Good;
         }
         catch (Exception ex)
@@ -650,6 +657,36 @@ public partial class WotConNodeManager : CustomNodeManager2
             _logger?.LogError(ex, "[WotCon] Exception in OnDeleteAsset");
             return new ServiceResult(StatusCodes.BadInternalError, ex.Message);
         }
+    }
+
+    private void ReportAssetModelChange(
+        ISystemContext context,
+        NodeId assetId,
+        ModelChangeStructureVerbMask verb)
+    {
+        var modelChangeEvent = new GeneralModelChangeEventState(null);
+        modelChangeEvent.Initialize(
+            context,
+            source: null,
+            EventSeverity.Low,
+            new Opc.Ua.LocalizedText("WoT asset address space changed."));
+        modelChangeEvent.SetChildValue(context, BrowseNames.SourceNode, ObjectIds.Server, copy: false);
+        modelChangeEvent.SetChildValue(context, BrowseNames.SourceName, "Server", copy: false);
+        modelChangeEvent.SetChildValue(
+            context,
+            BrowseNames.Changes,
+            new ModelChangeStructureDataType[]
+            {
+                new()
+                {
+                    Affected = assetId,
+                    AffectedType = ObjectTypeIds.BaseObjectType,
+                    Verb = (byte)verb,
+                },
+            },
+            copy: false);
+
+        Server.ReportEvent(modelChangeEvent);
     }
 
     /// <summary>

--- a/tests/CompanionSpecs/WotCon/WotConModelChangeEventTests.cs
+++ b/tests/CompanionSpecs/WotCon/WotConModelChangeEventTests.cs
@@ -1,0 +1,181 @@
+namespace OpcPlc.Tests.CompanionSpecs.WotCon;
+
+using FluentAssertions;
+using NUnit.Framework;
+using Opc.Ua;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Verifies model-change events raised by the WoT asset-management methods.
+/// </summary>
+[TestFixture]
+public class WotConModelChangeEventTests : SubscriptionTestsBase
+{
+    private const uint WotAssetConnectionManagementObjectId = 31;
+    private const uint CreateAssetMethodInstanceId = 32;
+    private const uint DeleteAssetMethodInstanceId = 35;
+    private const uint CreateAssetForEndpointTypeMethodId = 49;
+
+    private NodeId _eventType;
+
+    public WotConModelChangeEventTests() : base(["--wotcon"])
+    {
+    }
+
+    private ushort WotConNamespaceIndex => (ushort)Session.NamespaceUris.GetIndex(OpcPlc.Namespaces.WotCon);
+
+    [SetUp]
+    public async Task CreateMonitoredItem()
+    {
+        _eventType = ObjectTypeIds.GeneralModelChangeEventType;
+
+        SetUpMonitoredItem(Server, NodeClass.Object, Attributes.EventNotifier);
+
+        var filter = (EventFilter)MonitoredItem.Filter;
+        filter.WhereClause.Push(FilterOperator.OfType, _eventType);
+        filter.SelectClauses.Add(new SimpleAttributeOperand
+        {
+            TypeDefinitionId = _eventType,
+            BrowsePath = [new QualifiedName(BrowseNames.Changes)],
+            AttributeId = Attributes.Value,
+        });
+
+        await AddMonitoredItemAsync().ConfigureAwait(false);
+    }
+
+    [TearDown]
+    public void RemoveMonitoredItem()
+    {
+        Session.DefaultSubscription.RemoveItem(MonitoredItem);
+    }
+
+    [Test]
+    public async Task CreateAsset_ReportsNodeAdded()
+    {
+        ClearEvents();
+
+        var assetId = await CreateAssetAsync("ModelChangeCreate_" + Guid.NewGuid().ToString("N")[..8])
+            .ConfigureAwait(false);
+
+        AssertModelChange(assetId, ModelChangeStructureVerbMask.NodeAdded);
+    }
+
+    [Test]
+    public async Task CreateAssetForEndpoint_ReportsNodeAdded()
+    {
+        ClearEvents();
+
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        var (status, outputs) = await CallAsync(
+            WotConNodeId(WotAssetConnectionManagementObjectId),
+            WotConNodeId(CreateAssetForEndpointTypeMethodId),
+            [
+                new Variant("ModelChangeEndpoint_" + suffix),
+                new Variant($"opc.tcp://model-change-{suffix}.invalid:4840"),
+            ]).ConfigureAwait(false);
+
+        StatusCode.IsGood(status).Should().BeTrue("CreateAssetForEndpoint should succeed, got {0}", status);
+        var assetId = outputs.Should().ContainSingle().Subject.Value as NodeId;
+        NodeId.IsNull(assetId).Should().BeFalse();
+
+        AssertModelChange(assetId, ModelChangeStructureVerbMask.NodeAdded);
+    }
+
+    [Test]
+    public async Task DeleteAsset_ReportsNodeDeleted()
+    {
+        ClearEvents();
+
+        var assetId = await CreateAssetAsync("ModelChangeDelete_" + Guid.NewGuid().ToString("N")[..8])
+            .ConfigureAwait(false);
+
+        var (status, _) = await CallAsync(
+            WotConNodeId(WotAssetConnectionManagementObjectId),
+            WotConNodeId(DeleteAssetMethodInstanceId),
+            [new Variant(assetId)]).ConfigureAwait(false);
+
+        StatusCode.IsGood(status).Should().BeTrue("DeleteAsset should succeed, got {0}", status);
+
+        AssertModelChange(assetId, ModelChangeStructureVerbMask.NodeDeleted, expectedEventCount: 2);
+    }
+
+    private void AssertModelChange(
+        NodeId assetId,
+        ModelChangeStructureVerbMask expectedVerb,
+        int expectedEventCount = 1)
+    {
+        var receivedEvents = ReceiveAtMostEvents(expectedEventCount)
+            .Select(value => (EventFieldList)value.NotificationValue)
+            .Select(EventFieldListToDictionary)
+            .ToList();
+        var eventFields = receivedEvents.Should().ContainSingle(
+            fields => GetChanges(fields).Any(change =>
+                change.Affected == assetId
+                && ((ModelChangeStructureVerbMask)change.Verb).HasFlag(expectedVerb))).Subject;
+        eventFields.Should().Contain(new Dictionary<string, object>
+        {
+            ["/EventType"] = _eventType,
+            ["/SourceNode"] = Server,
+            ["/SourceName"] = "Server",
+        });
+
+        var change = GetChanges(eventFields).Should().ContainSingle().Subject;
+        change.Affected.Should().Be(assetId);
+        change.AffectedType.Should().Be(ObjectTypeIds.BaseObjectType);
+        ((ModelChangeStructureVerbMask)change.Verb).Should().HaveFlag(expectedVerb);
+    }
+
+    private static ModelChangeStructureDataType[] GetChanges(Dictionary<string, object> eventFields)
+    {
+        return eventFields["/Changes"] switch
+        {
+            ModelChangeStructureDataType[] values => values,
+            ExtensionObject[] values => values.Select(value => value.Body)
+                .OfType<ModelChangeStructureDataType>()
+                .ToArray(),
+            object value => throw new AssertionException(
+                $"Expected model-change structures but received {value?.GetType().FullName ?? "null"}."),
+        };
+    }
+
+    private async Task<NodeId> CreateAssetAsync(string assetName)
+    {
+        var (status, outputs) = await CallAsync(
+            WotConNodeId(WotAssetConnectionManagementObjectId),
+            WotConNodeId(CreateAssetMethodInstanceId),
+            [new Variant(assetName)]).ConfigureAwait(false);
+
+        StatusCode.IsGood(status).Should().BeTrue("CreateAsset should succeed, got {0}", status);
+        var assetId = outputs.Should().ContainSingle().Subject.Value as NodeId;
+        NodeId.IsNull(assetId).Should().BeFalse();
+        return assetId;
+    }
+
+    private async Task<(StatusCode Status, VariantCollection Outputs)> CallAsync(
+        NodeId objectId,
+        NodeId methodId,
+        VariantCollection arguments)
+    {
+        var response = await Session.CallAsync(
+            null,
+            new CallMethodRequestCollection
+            {
+                new CallMethodRequest
+                {
+                    ObjectId = objectId,
+                    MethodId = methodId,
+                    InputArguments = arguments,
+                },
+            },
+            CancellationToken.None).ConfigureAwait(false);
+
+        var result = response.Results.Should().ContainSingle().Subject;
+        return (result.StatusCode, result.OutputArguments ?? []);
+    }
+
+    private NodeId WotConNodeId(uint identifier) => new(identifier, WotConNamespaceIndex);
+}

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.15.2",
+  "version": "2.15.3",
   "versionHeightOffset": -1,
   "publicReleaseRefSpec": [
     "^refs/heads/main$",


### PR DESCRIPTION
This pull request introduces model-change event reporting for WoT asset management operations and adds comprehensive tests to verify this behavior. Now, when assets are created or deleted, the system emits OPC UA GeneralModelChangeEvent notifications, improving interoperability and client awareness of address space changes. The main changes are as follows:

**Model-Change Event Reporting:**

* Added a new private method `ReportAssetModelChange` to `WotConNodeManager.cs` that emits a `GeneralModelChangeEvent` whenever an asset is created or deleted, including details about the affected node and the type of change.
* Updated the `OnCreateAsset` and `OnDeleteAsset` methods to call `ReportAssetModelChange` after successful creation or deletion of an asset, ensuring clients are notified of these structural changes. [[1]](diffhunk://#diff-d664bf26e4ff47d6fcba7790aabbea7c79564ead5b0e344b8c9ed7d2af60aa53R548) [[2]](diffhunk://#diff-d664bf26e4ff47d6fcba7790aabbea7c79564ead5b0e344b8c9ed7d2af60aa53R648-R652)

**Code Quality Improvements:**

* Fixed the scope of the `deleted` variable in `OnDeleteAsset` to ensure its value is accessible after the deletion logic, improving code clarity and correctness. [[1]](diffhunk://#diff-d664bf26e4ff47d6fcba7790aabbea7c79564ead5b0e344b8c9ed7d2af60aa53R607) [[2]](diffhunk://#diff-d664bf26e4ff47d6fcba7790aabbea7c79564ead5b0e344b8c9ed7d2af60aa53L631-R633)

**Testing Enhancements:**

* Added a new test file `WotConModelChangeEventTests.cs` with tests that verify model-change events are raised with the correct verb (`NodeAdded` or `NodeDeleted`) when assets are created or deleted. This ensures the new event-reporting logic works as intended.…oint or deleteAsset are called (and changed the address space)

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->